### PR TITLE
Feature/sast dependency check

### DIFF
--- a/ci/travis/build/build.sh
+++ b/ci/travis/build/build.sh
@@ -18,4 +18,9 @@ echo "Setting the project version (mvn and npm) to the version: $BUILD_VERSION..
 ./mvnw initialize -DnewVersion=$BUILD_VERSION
 
 echo "Building and deploying Maven artifacts..."
-./mvnw deploy -Powasp-dependency-check
+if [ "$TRAVIS_BRANCH" == "master" ];
+then
+  ./mvnw deploy -Powasp-dependency-check;
+else
+  ./mvnw package;
+fi

--- a/ci/travis/build/build.sh
+++ b/ci/travis/build/build.sh
@@ -18,4 +18,4 @@ echo "Setting the project version (mvn and npm) to the version: $BUILD_VERSION..
 ./mvnw initialize -DnewVersion=$BUILD_VERSION
 
 echo "Building and deploying Maven artifacts..."
-./mvnw deploy
+./mvnw deploy -Powasp-dependency-check

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,60 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>owasp-dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>3.3.2</version>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <scanSet>
+                                <fileSet>
+                                    <!-- required in order to scan package.json -->
+                                    <directory>alv-portal-ui</directory>
+                                </fileSet>
+                            </scanSet>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>dependency-check-report</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>attach-dependency-report-artifact</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/dependency-check-report.html</file>
+                                            <type>html</type>
+                                            <classifier>dependency-check</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
example report:
https://alvch.jfrog.io/alvch/libs-releases-local/ch/admin/seco/alv-portal-parent/0.0.1-build-235-feature-sast-dependency-check/alv-portal-parent-0.0.1-build-235-feature-sast-dependency-check-dependency-check.html
- it just didn't find anything for the portal project (the github is doing here a better job for npm dependencies)