### PR TITLE
Remove the ngModel binding and use the native input element instead

### DIFF
--- a/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.html
@@ -41,7 +41,6 @@
              [focusFirst]="focusFirst"
              [editable]="editable"
              [readonly]="limit && control.value?.length >= limit"
-             [(ngModel)]="inputValue"
              (selectItem)="selectItem($event)"
              (keydown)="handleKeyDown($event)"
              (blur)="control.markAsTouched()">


### PR DESCRIPTION
The problem is that ng-boostrap does not update the "inputField" property that was bound to [(ngModel)], if the "editable" property is set to false. Now I use the native input element directly and it works fine. 