### PR TITLE
Testing/search ad effects spec tests

### DIFF
--- a/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
+++ b/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
@@ -125,7 +125,6 @@ describe('JobAdSearchEffects', () => {
      *    1st: ERROR response after 10 F + 10 F = 20 F delay
      *    2nd: value response after another 30 F + 10 F = 40 F delay
      *    3rd: end subscription after 60 F delay (irrelevant of response F)
-     * response delay here isn't counted because we are ending subscription after first triggering 'a'
      */
     it('should throw an EffectErrorOccurredAction on error, then proceed to another InitResultListAction, ' +
       'and finish with an FilterAppliedAction and terminate subscription to initJobSearch', () => {

--- a/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
+++ b/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
@@ -266,11 +266,6 @@ describe('JobAdSearchEffects', () => {
       const jobAd: any = { id: 'job-ad-001' };
       const result = [jobAd as JobAdvertisement];
 
-      const jobAdSearchResult = {
-        totalCount: 10,
-        result
-      };
-
       const loadNextJobAdvertisementDetailAction = new LoadNextJobAdvertisementDetailAction();
       const nextPageLoadedAction = new NextPageLoadedAction({ page: result });
 
@@ -279,8 +274,7 @@ describe('JobAdSearchEffects', () => {
         a: loadNextJobAdvertisementDetailAction,
         b: nextPageLoadedAction
       });
-      // response
-      jobAdService.search.and.returnValue(cold('-c', { c: jobAdSearchResult }));
+
       // expected
       const expected = cold('------d-', {
         d: { type: 'nothing' }

--- a/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
+++ b/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
@@ -76,7 +76,7 @@ describe('JobAdSearchEffects', () => {
       totalCount: 10
     });
 
-    it('should return a new FilterAppliedAction on success, and completes', () => {
+    it('should return a new FilterAppliedAction on success', () => {
       actions$ = hot('-a----', { a: initResultListAction });
       jobAdService.search.and.returnValue(cold('--b|', { b: jobAdSearchResult }));
 

--- a/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
+++ b/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
@@ -76,44 +76,74 @@ describe('JobAdSearchEffects', () => {
       totalCount: 10
     });
 
+    /*
+     * action : triggered 1x after 10 F and 40 F delay and after it continues
+     * response : returned after 20 F delay
+     * expected : 10 F + 20 F = 30 F delay before we emit 1st result, and 40 F + 20 F = 60 F delay before 2nd result
+     */
     it('should return a new FilterAppliedAction on success', () => {
-      actions$ = hot('-a----', { a: initResultListAction });
-      jobAdService.search.and.returnValue(cold('--b|', { b: jobAdSearchResult }));
 
-      const expected = cold('---c', {
-        c: new FilterAppliedAction({
-          page: result,
-          totalCount: 10
-        })
-      });
+      // action
+      actions$ = hot('-a--a--', { a: initResultListAction });
+      // response
+      jobAdService.search.and.returnValue(cold('--b|', { b: jobAdSearchResult }));
+      // expected
+      const expected = cold('---c--c-', { c: filterApplied });
 
       expect(sut.initJobSearch$).toBeObservable(expected);
     });
 
-    it('should complete after FilterAppliedAction', () => {
+    /*
+     * action : triggered 'a' 1x after 10 F delay and after it continues 2x with 'b' which shouldn't be executed
+     * response : returned empty response after 20 F delay and more importantly ends subscription
+     * expected : 10 F + ends subscription = 10 F delay before we emit result which is ending of subscription
+     *
+     * response delay here isn't counted because we are ending subscription after first triggering 'a'
+     */
+    it('should complete (unsubscribe) after FilterAppliedAction is triggered', () => {
 
+      // action
       actions$ = hot('-a-b--b-', {
         a: filterApplied,
         b: initResultListAction
       });
-      jobAdService.search.and.returnValue(cold('-c|', { c: {} }));
-
-      const expected = cold('-|--');
+      // response
+      jobAdService.search.and.returnValue(cold('--|', {}));
+      // expected
+      const expected = cold('-|----');
 
       expect(sut.initJobSearch$).toBeObservable(expected);
     });
 
+    /*
+     * action : triggered 'a' 2x after 10 F and 30 F delay and after it continues with 'b' after 60 F delay
+     * response : returned values :
+     *    1st: ERROR response after 10 F delay (for 1st 'a')
+     *    2nd: value response after 10 F delay (for 2nd 'a')
+     *    3rd: end subscription after filterApplied action (irrelevant of F delays) (for 'b')
+     * expected : 3 emitted actions, one from error and one successful action and ending subscription from initResultListAction
+     *    1st: ERROR response after 10 F + 10 F = 20 F delay
+     *    2nd: value response after another 30 F + 10 F = 40 F delay
+     *    3rd: end subscription after 60 F delay (irrelevant of response F)
+     * response delay here isn't counted because we are ending subscription after first triggering 'a'
+     */
     it('should throw an EffectErrorOccurredAction on error, then proceed to another InitResultListAction, ' +
       'and finish with an FilterAppliedAction and terminate subscription to initJobSearch', () => {
 
       const httpError = new HttpErrorResponse({});
 
-      actions$ = hot('-a-a--b', { a: initResultListAction, b: filterApplied });
+      // action
+      actions$ = hot('-a-a--b', {
+        a: initResultListAction,
+        b: filterApplied
+      });
+      // response
       jobAdService.search.and.returnValues(
         cold('-#', {}, httpError),
-        cold('-c|', {c: jobAdSearchResult})
+        cold('-c', {c: jobAdSearchResult}),
+        cold('-|', {})
       );
-
+      // expected
       const expected = cold('--e-d-|', {
         e: new EffectErrorOccurredAction({ httpError }),
         d: filterApplied
@@ -129,44 +159,111 @@ describe('JobAdSearchEffects', () => {
     const jobSearchFilter = initialState.jobSearchFilter;
     const applyFilterAction = new ApplyFilterAction(jobSearchFilter);
 
-    it('should return a new FilterAppliedAction on success, and completes with debouncing', () => {
+    const jobAd: any = { id: 1 };
+    const result = [jobAd as JobAdvertisement];
+    const jobAdSearchResult = {
+      totalCount: 10,
+      result
+    };
 
-      const jobAd: any = { id: 1 };
-      const result = [jobAd as JobAdvertisement];
-      const jobAdSearchResult = {
-        totalCount: 10,
-        result
-      };
+    const filterApplied = new FilterAppliedAction({
+      page: result,
+      totalCount: 10
+    });
 
+    const httpError = new HttpErrorResponse({});
+
+    /*
+     * action : triggered 3x, but only last 'a' is dispatched after 50 F delay
+     * response : returned after 10 F delay
+     * expected : 50 F + 10 F + 30 F from the debounce = 90 F delay before we emit result
+     */
+    it('should return a new FilterAppliedAction on success, and completes with de-bouncing', () => {
+
+      // action
       actions$ = hot('-a-a-a', { a: applyFilterAction });
+      // response
       jobAdService.search.and.returnValue(cold('-b|', { b: jobAdSearchResult }));
-      const expected = cold('---------c', { // debouncing 30 = 3 x _
-        c: new FilterAppliedAction({
-          page: result,
-          totalCount: 10
-        })
-      });
+      // expected
+      const expected = cold('---------c', { c: filterApplied });
 
       expect(sut.applyFilter$).toBeObservable(expected);
     });
 
+    /*
+     * action : triggered 3x, but only 2nd and 3rd 'a' are dispatched, 2nd after 30 F delay and 3rd after 70 F delay
+     * response : returned after 10 F delay (both actions)
+     * expected : emit 2 same action results,
+     *    1st: after 30 F + 10 F + 30 F from the debounce = 70 F delay
+     *    2nd: after 70 F + 10 F + 30 F from the debounce = 110 F delay (all together from the start!)
+     */
+    it('should return multiple new FilterAppliedAction on success, and completes with de-bouncing', () => {
+
+      // action
+      actions$ = hot('-a-a---a', { a: applyFilterAction });
+      // response
+      jobAdService.search.and.returnValue(cold('-b|', { b: jobAdSearchResult }));
+      // expected
+      const expected = cold('-------c---c', { c: filterApplied });
+
+      expect(sut.applyFilter$).toBeObservable(expected);
+    });
+
+    /*
+     * action : dispatched after 10 F delay
+     * response : return ERROR after 10 F delay
+     * expected : 10 F + 10 F + 30 F from the debounce = 50 F delay before we emit result
+     */
     it('should return an EffectErrorOccurredAction on error', () => {
 
-      const httpError = new HttpErrorResponse({});
-
-      actions$ = hot('-a---', { a: applyFilterAction });
+      // action
+      actions$ = hot('-a', { a: applyFilterAction });
+      // response
       jobAdService.search.and.returnValue(cold('-#|', {}, httpError));
+      // expected
       const expected = cold('-----c', {
         c: new EffectErrorOccurredAction({ httpError })
       });
 
       expect(sut.applyFilter$).toBeObservable(expected);
     });
+
+    /*
+     * action : dispatched after 10 F delay and after debounce again after 50 F delay
+     * response : return ERROR after 10 F delay, and another response is correct result after additional 10 F delay
+     * expected : two emitted results, one error and one successful
+     *    1st: after 10 F + 10 F + 30 F debounce = 50 F delay (emitted ERROR)
+     *    2nd: after 50 F + 10 F + 30 F debounce = 90 F delay (emitted valid result)
+     */
+    it('should return an EffectErrorOccurredAction on error, and after it correct result', function () {
+      // action
+      actions$ = hot('-a---a-', { a: applyFilterAction });
+      // response
+      jobAdService.search.and.returnValues(
+          cold('-#', {}, httpError),
+          cold('-b', {b: jobAdSearchResult})
+      );
+      // expected
+      const expected = cold('-----e---c-', {
+        e: new EffectErrorOccurredAction({ httpError }),
+        c: filterApplied
+      });
+
+      expect(sut.applyFilter$).toBeObservable(expected);
+    });
+
   });
 
   describe('loadNextJobAdvertisementDetail$', () => {
 
+    /*
+     * action : triggered 3x, 'a' after 10 F  and 30 F delay, and 'b' after 60 F delay
+     * response : returned after 10 F delay result (irrelevant because we are actually triggering
+     *    nextPageLoadedAction in H.O. so it's already returned response there, with no delay
+     * expected : emit result after 60 F delay, when we get nextPageLoadedAction
+     */
     it('should load next job ad', () => {
+
       const jobAd: any = { id: 'job-ad-001' };
       const result = [jobAd as JobAdvertisement];
 
@@ -178,14 +275,16 @@ describe('JobAdSearchEffects', () => {
       const loadNextJobAdvertisementDetailAction = new LoadNextJobAdvertisementDetailAction();
       const nextPageLoadedAction = new NextPageLoadedAction({ page: result });
 
-      actions$ = hot('-a-b--b', {
+      // action
+      actions$ = hot('-a-a--b--', {
         a: loadNextJobAdvertisementDetailAction,
         b: nextPageLoadedAction
       });
-      jobAdService.search.and.returnValue(cold('-b|', { b: jobAdSearchResult }));
-
-      const expected = cold('---c---', {
-        c: { type: 'nothing' }
+      // response
+      jobAdService.search.and.returnValue(cold('-c', { c: jobAdSearchResult }));
+      // expected
+      const expected = cold('------d-', {
+        d: { type: 'nothing' }
       });
 
       expect(sut.loadNextJobAdvertisementDetail$).toBeObservable(expected);

--- a/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
+++ b/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
@@ -18,7 +18,7 @@ import {
   LoadNextJobAdvertisementDetailAction,
   NextPageLoadedAction
 } from '../actions/job-ad-search.actions';
-import { Observable } from 'rxjs/index';
+import { Observable } from 'rxjs';
 import { JobAdvertisement } from '../../../shared/backend-services/job-advertisement/job-advertisement.types';
 import { jobAdSearchReducer } from '../reducers/job-ad-search.reducers';
 import { OccupationSuggestionService } from '../../../shared/occupations/occupation-suggestion.service';
@@ -77,10 +77,10 @@ describe('JobAdSearchEffects', () => {
     });
 
     it('should return a new FilterAppliedAction on success, and completes', () => {
-      actions$ = hot('-a--a-', { a: initResultListAction });
+      actions$ = hot('-a----', { a: initResultListAction });
       jobAdService.search.and.returnValue(cold('--b|', { b: jobAdSearchResult }));
 
-      const expected = cold('---c|-', {
+      const expected = cold('---c', {
         c: new FilterAppliedAction({
           page: result,
           totalCount: 10

--- a/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
+++ b/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.spec.ts
@@ -22,8 +22,8 @@ import { Observable } from 'rxjs';
 import { JobAdvertisement } from '../../../shared/backend-services/job-advertisement/job-advertisement.types';
 import { jobAdSearchReducer } from '../reducers/job-ad-search.reducers';
 import { OccupationSuggestionService } from '../../../shared/occupations/occupation-suggestion.service';
-import { HttpErrorResponse } from "@angular/common/http";
-import { EffectErrorOccurredAction } from "../../../core/state-management/actions/core.actions";
+import { HttpErrorResponse } from '@angular/common/http';
+import { EffectErrorOccurredAction } from '../../../core/state-management/actions/core.actions';
 import SpyObj = jasmine.SpyObj;
 
 describe('JobAdSearchEffects', () => {

--- a/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.ts
+++ b/alv-portal-ui/src/app/job-ad-search/state-management/effects/job-ad-search.effects.ts
@@ -17,6 +17,7 @@ import {
   NEXT_PAGE_LOADED,
   NextPageLoadedAction,
   OccupationLanguageChangedAction,
+  FILTER_APPLIED,
   RESET_FILTER
 } from '../actions/job-ad-search.actions';
 import { JobAdvertisementRepository } from '../../../shared/backend-services/job-advertisement/job-advertisement.repository';
@@ -60,16 +61,15 @@ export class JobAdSearchEffects {
   @Effect()
   initJobSearch$ = this.actions$.pipe(
     ofType(INIT_RESULT_LIST),
-    take(1),
     withLatestFrom(this.store.pipe(select(getJobAdSearchState))),
     switchMap(([action, state]) => this.jobAdvertisementRepository.search(JobSearchRequestMapper.mapToRequest(state.jobSearchFilter, state.page)).pipe(
-      map((response) => new FilterAppliedAction({
-        page: response.result,
-        totalCount: response.totalCount
-      })),
-      catchError((errorResponse) => of(new EffectErrorOccurredAction({ httpError: errorResponse })))
-    )),
-    takeUntil(this.actions$.pipe(ofType(APPLY_FILTER))),
+        map((response) => new FilterAppliedAction({
+            page: response.result,
+            totalCount: response.totalCount
+          })),
+        catchError((errorResponse) => of(new EffectErrorOccurredAction({ httpError: errorResponse })))
+      )),
+    takeUntil(this.actions$.pipe(ofType(FILTER_APPLIED))),
   );
 
   @Effect()


### PR DESCRIPTION
Add several new unit tests on job search ad effects, and made some changes on current ones.
Remove take(1) from initJobSearch$ action, and replaced APPLY_FILTER with FILTER_APPLIED because it represents a successful action.