### PR TITLE
DF-479: Add showGroupErrors attribute to the input components

### DIFF
--- a/alv-portal-ui/src/app/shared/forms/input/abstract-input.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/abstract-input.ts
@@ -49,12 +49,18 @@ export abstract class AbstractInput implements OnInit {
    */
   @Input() autofocus?: boolean;
 
+  /**
+   * if true, displays the parent group errors
+   * @type {boolean}
+   */
+  @Input() showGroupErrors = false;
+
   validationId: string;
 
   protected constructor(
-      private controlContainer: ControlContainer,
-      private inputType: InputType,
-      private inputIdGenerationService: InputIdGenerationService) {
+    private controlContainer: ControlContainer,
+    private inputType: InputType,
+    private inputIdGenerationService: InputIdGenerationService) {
   }
 
   ngOnInit() {
@@ -68,6 +74,27 @@ export abstract class AbstractInput implements OnInit {
 
     this.id = this.id || this.inputIdGenerationService.getNextInputId(this.inputType, this.label);
     this.validationId = `${this.id}-validation`;
+  }
+
+  public isTouched() {
+    if (this.control.parent && this.showGroupErrors) {
+      return this.control.parent.touched || this.control.touched;
+    }
+
+    return this.control.touched;
+  }
+
+  public isInvalid() {
+    if (this.control.parent && this.showGroupErrors && this.control.parent.invalid) {
+      const parentErrors = this.control.parent.errors || {};
+      const hasRelevantGroupError = (this.validationMessages || [])
+        .map((msg) => msg.error)
+        .reduce((accumulator, currentValue) => !!parentErrors[currentValue] || accumulator, false);
+
+      return hasRelevantGroupError || this.control.invalid;
+    }
+
+    return this.control.invalid;
   }
 
   public get control() {

--- a/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.html
@@ -16,3 +16,8 @@
                          [attr.id]="validationId"
                          [customValidationMessages]="validationMessages">
 </alv-validation-messages>
+<alv-validation-messages *ngIf="!readonly && showGroupErrors"
+                         [control]="control.parent"
+                         [attr.id]="validationId"
+                         [customValidationMessages]="validationMessages">
+</alv-validation-messages>

--- a/alv-portal-ui/src/app/shared/forms/input/date-input/date-input.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/date-input/date-input.component.html
@@ -1,7 +1,7 @@
 <div class="form-group"
      *ngIf="control">
   <div class="form-label-group position-relative d-flex"
-       [class.invalid]="control.touched && control.invalid">
+       [class.invalid]="isTouched() && isInvalid()">
     <span *ngIf="!!required && !readonly"
           class="required-indicator h-100">
     </span>
@@ -44,12 +44,17 @@
       </button>
     </span>
   </div>
-  <small *ngIf="helpText && !(control.touched && control.invalid)"
-         class="help-text" >
+  <small *ngIf="helpText && !(isTouched() && isInvalid())"
+         class="help-text">
     {{helpText | translate}}
   </small>
   <alv-validation-messages *ngIf="!readonly"
                            [control]="control"
+                           [attr.id]="validationId"
+                           [customValidationMessages]="validationMessages">
+  </alv-validation-messages>
+  <alv-validation-messages *ngIf="!readonly && showGroupErrors"
+                           [control]="control.parent"
                            [attr.id]="validationId"
                            [customValidationMessages]="validationMessages">
   </alv-validation-messages>

--- a/alv-portal-ui/src/app/shared/forms/input/input-field/input-field.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/input-field/input-field.component.html
@@ -2,7 +2,7 @@
      *ngIf="control">
 
   <div class="form-label-group position-relative"
-       [class.invalid]="control.touched && control.invalid">
+       [class.invalid]="isTouched() && isInvalid()">
     <span *ngIf="required && !readonly"
           class="required-indicator h-100">
     </span>
@@ -45,10 +45,11 @@
       </span>
     </label>
   </div>
-  <div *ngIf="!(control.touched && control.invalid)"
+  <div *ngIf="!(isTouched() && isInvalid())"
        class="help-text d-flex">
     <small *ngIf="helpText"
-           class="mt-1">{{helpText | translate}}</small>
+           class="mt-1">{{helpText | translate}}
+    </small>
     <div class="flex-grow-1"></div>
     <small *ngIf="showCharacterCounter"
            class="mt-1">
@@ -58,6 +59,11 @@
 
   <alv-validation-messages *ngIf="!readonly"
                            [control]="control"
+                           [attr.id]="validationId"
+                           [customValidationMessages]="validationMessages">
+  </alv-validation-messages>
+  <alv-validation-messages *ngIf="!readonly && showGroupErrors"
+                           [control]="control.parent"
                            [attr.id]="validationId"
                            [customValidationMessages]="validationMessages">
   </alv-validation-messages>

--- a/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.html
@@ -1,7 +1,7 @@
 <div class="w-100 form-group"
      *ngIf="control">
   <div class="form-label-group position-relative"
-       [class.invalid]="control.touched && control.invalid">
+       [class.invalid]="isTouched() && isInvalid()">
     <span *ngIf="required && !readonly"
           class="required-indicator h-100">
     </span>
@@ -109,12 +109,17 @@
     </ng-template>
 
   </div>
-  <small *ngIf="helpText && !(control.touched && control.invalid)"
+  <small *ngIf="helpText && !(isTouched() && isInvalid())"
          class="help-text" >
     {{helpText | translate}}
   </small>
   <alv-validation-messages *ngIf="!readonly"
                            [control]="control"
+                           [attr.id]="validationId"
+                           [customValidationMessages]="validationMessages">
+  </alv-validation-messages>
+  <alv-validation-messages *ngIf="!readonly && showGroupErrors"
+                           [control]="control.parent"
                            [attr.id]="validationId"
                            [customValidationMessages]="validationMessages">
   </alv-validation-messages>

--- a/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.html
@@ -27,3 +27,8 @@
                          [attr.id]="validationId"
                          [customValidationMessages]="validationMessages">
 </alv-validation-messages>
+<alv-validation-messages *ngIf="!readonly && showGroupErrors"
+                         [control]="control.parent"
+                         [attr.id]="validationId"
+                         [customValidationMessages]="validationMessages">
+</alv-validation-messages>

--- a/alv-portal-ui/src/app/shared/forms/input/select/select.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/select/select.component.html
@@ -1,7 +1,7 @@
 <div class="form-group"
      *ngIf="control">
   <div class="form-label-group position-relative"
-       [class.invalid]="control.touched && control.invalid"
+       [class.invalid]="isTouched() && isInvalid()"
        [class.readonly]="readonly">
     <span class="required-indicator"
           *ngIf="required && !readonly"></span>
@@ -32,12 +32,17 @@
     <i class="fas fa-caret-down dropdown-icon"
        *ngIf="!readonly"></i>
   </div>
-  <small *ngIf="helpText && !(control.touched && control.invalid)"
+  <small *ngIf="helpText && !(isTouched() && isInvalid())"
          class="help-text" >
     {{helpText | translate}}
   </small>
   <alv-validation-messages *ngIf="!readonly"
                            [control]="control"
+                           [attr.id]="validationId"
+                           [customValidationMessages]="validationMessages">
+  </alv-validation-messages>
+  <alv-validation-messages *ngIf="!readonly && showGroupErrors"
+                           [control]="control.parent"
                            [attr.id]="validationId"
                            [customValidationMessages]="validationMessages">
   </alv-validation-messages>

--- a/alv-portal-ui/src/app/shared/forms/input/single-typeahead/single-typeahead.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/single-typeahead/single-typeahead.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="control"
      class="w-100 form-group">
-  <div [class.invalid]="control.touched && control.invalid"
+  <div [class.invalid]="isTouched() && isInvalid()"
        class="form-label-group position-relative">
     <span *ngIf="required && !readonly"
           class="required-indicator h-100">
@@ -51,7 +51,7 @@
     </ng-template>
 
   </div>
-  <small *ngIf="helpText && !(control.touched && control.invalid)"
+  <small *ngIf="helpText && !(isTouched() && isInvalid())"
          class="help-text" >
     {{helpText | translate}}
   </small>
@@ -59,5 +59,10 @@
                            [control]="control"
                            [customValidationMessages]="validationMessages"
                            [attr.id]="validationId">
+  </alv-validation-messages>
+  <alv-validation-messages *ngIf="!readonly && showGroupErrors"
+                           [control]="control.parent"
+                           [attr.id]="validationId"
+                           [customValidationMessages]="validationMessages">
   </alv-validation-messages>
 </div>

--- a/alv-portal-ui/src/app/shared/forms/validation.service.ts
+++ b/alv-portal-ui/src/app/shared/forms/validation.service.ts
@@ -51,11 +51,10 @@ export class ValidationService {
     if (!customValidationMessages || customValidationMessages.length === 0) {
       return this.defaultValidationMessages;
     } else {
-      return this.defaultValidationMessages.map(
+      return [...this.defaultValidationMessages.map(
         validationMessage => customValidationMessages.find(
-          customValidationMessage => customValidationMessage.error === validationMessage.error
-          )
-          || validationMessage);
+          customValidationMessage => customValidationMessage.error === validationMessage.error)
+          || validationMessage), ...customValidationMessages];
     }
   }
 


### PR DESCRIPTION
Example:

Html:
```
 <alv-input-field label="home.tools.job-publication.company.street"
                       alvFormControlName="street"
                       [showGroupErrors]="true"
                       [validationMessages]="[{
                                error: 'postOfficeBoxNumberOrStreetRequired',
                                message: 'home.tools.job-publication.messages.validate.at-least-one-required-street-or-pobox'}
                                ]">
      </alv-input-field>
```

Cross-field validator:
```
function companyGroupValidator(companyGroup: FormGroup): ValidationErrors | null {
  const streetValue = companyGroup.get('street').value;
  const postOfficeBoxNumberValue = companyGroup.get('postOfficeBoxNumber').value;

  if (!!streetValue || !!postOfficeBoxNumberValue) {
    return null;
  }

  return {
    'postOfficeBoxNumberOrStreetRequired': true
  };
}
```
UI:
![selection_139](https://user-images.githubusercontent.com/21288589/51115064-73e90700-1807-11e9-9441-2a071ef21a10.png)
