### PR TITLE
Radio Button + some CSS fixes

### DIFF
--- a/alv-portal-ui/src/app/registration/finish-registration/role-selection/role-selection.component.scss
+++ b/alv-portal-ui/src/app/registration/finish-registration/role-selection/role-selection.component.scss
@@ -1,3 +1,3 @@
 .terms-of-use {
-  margin-left: 30px;
+  margin-left: 2rem;
 }

--- a/alv-portal-ui/src/app/shared/forms/input/abstract-checkbox-radio.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/abstract-checkbox-radio.scss
@@ -9,45 +9,44 @@
     position: relative;
     display: inline-block;
     cursor: pointer;
+    &::before,
+    &::after {
+      position: absolute;
+      content: "";
+      display: inline-block;
+    }
+
+    &:hover::before {
+      background-color: $color-super-light-grey;
+    }
+
   }
 
   input {
     opacity: 0;
-  }
+    /* Hide the check mark by default */
+    & + label::after {
+      transition: all 0.25s ease-out;
+      opacity: 0;
+    }
 
-  label::before,
-  label::after {
-    position: absolute;
-    content: "";
-    display: inline-block;
-  }
+    /* Unhide on the checked state */
+    &:checked + label::after {
+      opacity: 1;
+    }
 
-  label:hover::before {
-    background-color: $color-super-light-grey;
-  }
+    /* Adding focus styles on the outer-box of the fake checkbox */
+    &:focus + label::before {
+      box-shadow: 0 0 0 0.2rem $color-blue-transparent;
+    }
 
-  /* Hide the check mark by default */
-  input + label::after {
-    transition: all 0.25s ease-out;
-    opacity: 0;
-  }
-
-  /* Unhide on the checked state */
-  input:checked + label::after {
-    opacity: 1;
-  }
-
-  /* Adding focus styles on the outer-box of the fake checkbox */
-  input:focus + label::before {
-    box-shadow: 0 0 0 0.2rem $color-blue-transparent;
-  }
-
-  input:disabled + label {
-    cursor: default;
-    &::before {
-      background: $color-light-grey;
-      opacity: 0.6;
-      pointer-events: none;
+    &:disabled + label {
+      cursor: default;
+      &::before {
+        background: $color-light-grey;
+        opacity: 0.6;
+        pointer-events: none;
+      }
     }
   }
 }

--- a/alv-portal-ui/src/app/shared/forms/input/abstract-checkbox-radio.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/abstract-checkbox-radio.scss
@@ -26,7 +26,7 @@
     opacity: 0;
     /* Hide the check mark by default */
     & + label::after {
-      transition: all 0.25s ease-out;
+      transition: all 0.15s ease-out;
       opacity: 0;
     }
 

--- a/alv-portal-ui/src/app/shared/forms/input/abstract-checkbox-radio.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/abstract-checkbox-radio.scss
@@ -1,0 +1,54 @@
+@import "../../../../scss/common/colors";
+
+/**
+ * Checkbox/radio button implementation inspired by
+ * https://medium.com/claritydesignsystem/pure-css-accessible-checkboxes-and-radios-buttons-54063e759bb3
+ */
+.checkbox-radio {
+  label {
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+  }
+
+  input {
+    opacity: 0;
+  }
+
+  label::before,
+  label::after {
+    position: absolute;
+    content: "";
+    display: inline-block;
+  }
+
+  label:hover::before {
+    background-color: $color-super-light-grey;
+  }
+
+  /* Hide the check mark by default */
+  input + label::after {
+    transition: all 0.25s ease-out;
+    opacity: 0;
+  }
+
+  /* Unhide on the checked state */
+  input:checked + label::after {
+    opacity: 1;
+  }
+
+  /* Adding focus styles on the outer-box of the fake checkbox */
+  input:focus + label::before {
+    box-shadow: 0 0 0 0.2rem $color-blue-transparent;
+  }
+
+  input:disabled + label {
+    cursor: default;
+    &::before {
+      background: $color-light-grey;
+      opacity: 0.6;
+      pointer-events: none;
+    }
+  }
+}
+

--- a/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.html
@@ -1,4 +1,4 @@
-<div class="checkbox"
+<div class="checkbox-radio"
      *ngIf="control">
   <input class="form-check-input"
          type="checkbox"

--- a/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.scss
@@ -4,43 +4,18 @@
   padding-left: 2rem;
 }
 
-/**
- * Checkbox implementation inspired by
- * https://medium.com/claritydesignsystem/pure-css-accessible-checkboxes-and-radios-buttons-54063e759bb3
- */
-.checkbox {
-  label {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-  }
-
-  input {
-    opacity: 0;
-  }
-
-  label::before,
-  label::after {
-    position: absolute;
-    content: "";
-    display: inline-block;
-  }
-
+.checkbox-radio {
   /* Outer box of the fake checkbox */
   label::before {
-    height: 20px;
-    width: 20px;
+    height: 18px;
+    width: 18px;
 
     border: 1px solid $color-grey;
     background-color: $color-white;
     border-radius: 2px;
 
     left: 0;
-    top: 2px;
-  }
-
-  label:hover::before {
-    background-color: $color-super-light-grey;
+    top: 3px;
   }
 
   /* Check mark of the fake checkbox */
@@ -53,33 +28,7 @@
     border-color: $color-dark-grey;
     transform: rotate(-45deg);
 
-    left: 5px;
+    left: 4px;
     top: 7px;
   }
-
-  /* Hide the check mark by default */
-  input + label::after {
-    transition: all 0.25s ease-out;
-    opacity: 0;
-  }
-
-  /* Unhide on the checked state */
-  input:checked + label::after {
-    opacity: 1;
-  }
-
-  /* Adding focus styles on the outer-box of the fake checkbox */
-  input:focus + label::before {
-    box-shadow: 0 0 0 0.2rem $color-blue-transparent;
-  }
-
-  input:disabled + label {
-    cursor: default;
-    &::before {
-      background: $color-light-grey;
-      opacity: 0.6;
-      pointer-events: none;
-    }
-  }
 }
-

--- a/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/checkbox/checkbox.component.ts
@@ -7,7 +7,7 @@ import { ControlContainer } from '@angular/forms';
 @Component({
   selector: 'alv-checkbox',
   templateUrl: './checkbox.component.html',
-  styleUrls: ['./checkbox.component.scss']
+  styleUrls: ['../abstract-checkbox-radio.scss', './checkbox.component.scss']
 })
 export class CheckboxComponent extends AbstractInput {
 

--- a/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.html
@@ -50,7 +50,7 @@
     </div>
     <label class="d-flex"
            [attr.for]="id">
-      {{label | translate}}
+      <span class="label text-truncate">{{label | translate}}</span>
       <span class="flex-grow-1"></span>
       <span *ngIf="limit && control.value?.length">
         {{control.value?.length + '/' + limit}}

--- a/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/multi-typeahead/multi-typeahead.component.scss
@@ -20,6 +20,9 @@
       padding: 0 !important;
       border: 0;
     }
+    label .label {
+      max-width: 100%;
+    }
     fieldset {
       .typeahead-badge {
         font-weight: 500;

--- a/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.html
@@ -5,8 +5,8 @@
   <legend class="label mb-2"
           *ngIf="label">{{label | translate}}
   </legend>
-  <div class="radio"
-       *ngFor="let option of options$ | async">
+  <div class="checkbox-radio"
+       *ngFor="let option of options$ | async; let first = first">
     <input class="form-check-input"
            type="radio"
            [formControl]="control"
@@ -14,7 +14,7 @@
            [value]="option.value"
            [attr.id]="id + '-' + option.value"
            [attr.aria-readonly]="readonly"
-           [alvAutofocus]="autofocus"
+           [alvAutofocus]="first ? autofocus : false"
            (click)="!readonly">
     <label class="form-check-label"
            [for]="id + '-' + option.value"

--- a/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.html
@@ -5,7 +5,7 @@
   <legend class="label mb-2"
           *ngIf="label">{{label | translate}}
   </legend>
-  <div class="form-check"
+  <div class="radio"
        *ngFor="let option of options$ | async">
     <input class="form-check-input"
            type="radio"

--- a/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.scss
@@ -20,7 +20,7 @@
 }
 
 .checkbox-radio {
-  /* Outer box of the fake checkbox */
+  /* Outer box of the fake radio button */
   label::before {
     height: 18px;
     width: 18px;
@@ -33,7 +33,7 @@
     top: 3px;
   }
 
-  /* Checkmark of the fake checkbox */
+  /* Check mark of the fake radio button */
   label::after {
     height: 10px;
     width: 10px;

--- a/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.scss
@@ -1,12 +1,10 @@
+@import "../../../../../scss/common/colors";
+
 .label {
   font-size: 16px;
 }
 
-.form-check-label {
-  margin-left: 10px;
-}
-
-.form-check:not(:first-of-type) {
+.radio:not(:first-of-type) {
   margin-top: 0.5rem;
 }
 
@@ -16,3 +14,79 @@
     margin-bottom: 0;
   }
 }
+
+.form-check-label {
+  padding-left: 2rem;
+}
+
+.radio {
+  label {
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+  }
+
+  input {
+    opacity: 0;
+  }
+
+  label::before,
+  label::after {
+    position: absolute;
+    content: "";
+    display: inline-block;
+  }
+
+  /* Outer box of the fake checkbox */
+  label::before {
+    height: 20px;
+    width: 20px;
+
+    border: 1px solid $color-grey;
+    background-color: $color-white;
+    border-radius: 50%;
+
+    left: 0;
+    top: 2px;
+  }
+
+  label:hover::before {
+    background-color: $color-super-light-grey;
+  }
+
+  /* Checkmark of the fake checkbox */
+  label::after {
+    height: 10px;
+    width: 10px;
+    background-color: $color-dark-grey;
+    border-radius: 50%;
+    left: 5px;
+    top: 7px;
+  }
+
+  /* Hide the checkmark by default */
+  input + label::after {
+    transition: all 0.25s ease-out;
+    opacity: 0;
+  }
+
+  /* Unhide on the checked state */
+  input:checked + label::after {
+    opacity: 1;
+  }
+
+  /* Adding focus styles on the outer-box of the fake checkbox */
+  input:focus + label::before {
+    box-shadow: 0 0 0 0.2rem $color-blue-transparent;
+  }
+
+  input:disabled + label {
+    cursor: default;
+    &::before {
+      background: $color-light-grey;
+      opacity: 0.6;
+      pointer-events: none;
+    }
+  }
+}
+

--- a/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.scss
@@ -4,7 +4,7 @@
   font-size: 16px;
 }
 
-.radio:not(:first-of-type) {
+.checkbox-radio:not(:first-of-type) {
   margin-top: 0.5rem;
 }
 
@@ -19,39 +19,18 @@
   padding-left: 2rem;
 }
 
-.radio {
-  label {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-  }
-
-  input {
-    opacity: 0;
-  }
-
-  label::before,
-  label::after {
-    position: absolute;
-    content: "";
-    display: inline-block;
-  }
-
+.checkbox-radio {
   /* Outer box of the fake checkbox */
   label::before {
-    height: 20px;
-    width: 20px;
+    height: 18px;
+    width: 18px;
 
     border: 1px solid $color-grey;
     background-color: $color-white;
     border-radius: 50%;
 
     left: 0;
-    top: 2px;
-  }
-
-  label:hover::before {
-    background-color: $color-super-light-grey;
+    top: 3px;
   }
 
   /* Checkmark of the fake checkbox */
@@ -60,33 +39,8 @@
     width: 10px;
     background-color: $color-dark-grey;
     border-radius: 50%;
-    left: 5px;
+    left: 4px;
     top: 7px;
-  }
-
-  /* Hide the checkmark by default */
-  input + label::after {
-    transition: all 0.25s ease-out;
-    opacity: 0;
-  }
-
-  /* Unhide on the checked state */
-  input:checked + label::after {
-    opacity: 1;
-  }
-
-  /* Adding focus styles on the outer-box of the fake checkbox */
-  input:focus + label::before {
-    box-shadow: 0 0 0 0.2rem $color-blue-transparent;
-  }
-
-  input:disabled + label {
-    cursor: default;
-    &::before {
-      background: $color-light-grey;
-      opacity: 0.6;
-      pointer-events: none;
-    }
   }
 }
 

--- a/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/radio-button/radio-button.component.ts
@@ -9,7 +9,7 @@ import { ControlContainer } from '@angular/forms';
 @Component({
   selector: 'alv-radio-button',
   templateUrl: './radio-button.component.html',
-  styleUrls: ['./radio-button.component.scss']
+  styleUrls: ['../abstract-checkbox-radio.scss', './radio-button.component.scss']
 })
 export class RadioButtonComponent extends AbstractSelectableInput implements OnInit {
 

--- a/alv-portal-ui/src/app/shared/forms/input/single-typeahead/single-typeahead.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/single-typeahead/single-typeahead.component.html
@@ -24,7 +24,8 @@
            [resultTemplate]="template"
            class="form-control">
 
-    <label [attr.for]="id">
+    <label [attr.for]="id"
+           class="text-truncate">
       {{label | translate}}
     </label>
 

--- a/alv-portal-ui/src/app/shared/forms/input/single-typeahead/single-typeahead.component.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/single-typeahead/single-typeahead.component.scss
@@ -25,6 +25,10 @@
       border: 0;
     }
 
+    label {
+      max-width: 100%;
+    }
+
     fieldset {
       height: 21px;
 

--- a/alv-portal-ui/src/scss/overrides/dropdown.scss
+++ b/alv-portal-ui/src/scss/overrides/dropdown.scss
@@ -3,7 +3,7 @@
 .dropdown-menu {
   border-radius: 0;
   padding: .1rem 0;
-  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.35);
+  box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.35);
 
   .dropdown-item {
     border-left: 5px solid transparent;

--- a/alv-portal-ui/src/scss/overrides/dropdown.scss
+++ b/alv-portal-ui/src/scss/overrides/dropdown.scss
@@ -3,6 +3,7 @@
 .dropdown-menu {
   border-radius: 0;
   padding: .1rem 0;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.35);
 
   .dropdown-item {
     border-left: 5px solid transparent;


### PR DESCRIPTION
- created a shared style file for radio button and checkbox
<img width="827" alt="screenshot 2019-01-15 at 22 02 51" src="https://user-images.githubusercontent.com/18017179/51209861-8e0f0c00-1911-11e9-80b4-69ec9f48f0ab.png">

- fixed the `autofocus` feature of the radio-button.component
- fixed the truncation of labels of multi- and singe-typeahead.component
<img width="840" alt="screenshot 2019-01-15 at 22 03 08" src="https://user-images.githubusercontent.com/18017179/51209873-96674700-1911-11e9-8bd4-a520ec68d519.png">

- added the desired `box-shadow` for all dropdown menus
<img width="427" alt="screenshot 2019-01-15 at 22 04 13" src="https://user-images.githubusercontent.com/18017179/51209878-9b2bfb00-1911-11e9-8cab-b6fc4cb4e727.png">
