### PR TITLE
Increase the duration of the "truncate animation" to match longer text sizes

### DIFF
--- a/alv-portal-ui/src/app/shared/layout/main-navigation/main-navigation.component.scss
+++ b/alv-portal-ui/src/app/shared/layout/main-navigation/main-navigation.component.scss
@@ -16,7 +16,7 @@
   height: 100%;
 
   ::ng-deep .nav-item > .nav-text {
-    animation: expandMainMenu 0.25s ease-out;
+    animation: expandMainMenu 0.4s ease-out;
   }
 
   /* Collapsed desktop menu style */


### PR DESCRIPTION
I have seen while testing that the expand animation of the main navigation is flickering again. This was because of the longer text sizes of the Italian language. I've now improved the animation and tested with the maximal possible text size. Multi line text labels would be possible, too.