### PR TITLE
Add search icon for single-typeahead

### DIFF
--- a/alv-portal-ui/src/app/shared/forms/input/typeahead/single-typeahead/single-typeahead.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/typeahead/single-typeahead/single-typeahead.component.html
@@ -43,6 +43,8 @@
       {{'portal.typeahead-single.help-text.instruction' | translate : {'number' : TYPEAHEAD_QUERY_MIN_LENGTH} }}
     </div>
 
+    <i class="search-icon fas fa-search"></i>
+
     <ng-template #template
                  let-formatter="formatter"
                  let-result="result"

--- a/alv-portal-ui/src/app/shared/forms/input/typeahead/single-typeahead/single-typeahead.component.scss
+++ b/alv-portal-ui/src/app/shared/forms/input/typeahead/single-typeahead/single-typeahead.component.scss
@@ -55,7 +55,20 @@
       }
     }
   }
+
+  .search-icon {
+    position: absolute;
+    right: 0.65em;
+    top: 0.65em;
+    font-size: 1.25rem;
+    pointer-events: none;
+    color: $color-dark-grey
+  }
+  &.invalid .search-icon {
+    color: $color-red;
+  }
 }
+
 
 /* Grouping styles */
 .typeahead-group-label {

--- a/alv-portal-ui/src/app/shared/forms/input/typeahead/single-typeahead/single-typeahead.component.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/typeahead/single-typeahead/single-typeahead.component.ts
@@ -4,7 +4,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  Host,
+  Host, HostBinding,
   Input,
   OnInit,
   Optional,
@@ -28,6 +28,11 @@ import { TypeaheadItem } from '../typeahead-item';
   styleUrls: ['../../abstract-input.scss', './single-typeahead.component.scss']
 })
 export class SingleTypeaheadComponent extends AbstractInput implements OnInit, AfterViewInit {
+
+  /**
+   * CSS class providing space for the search icon on the right
+   */
+  @HostBinding('class.append-button') readonly appendButtonClass = true;
 
   readonly TYPEAHEAD_QUERY_MIN_LENGTH = 2;
 


### PR DESCRIPTION
### Normal style
<img width="523" alt="screenshot 2019-01-25 at 14 44 47" src="https://user-images.githubusercontent.com/18017179/51749500-d36ccf80-20af-11e9-9c29-3b78ac1a7ce4.png">

### Invalid style
<img width="523" alt="screenshot 2019-01-25 at 14 44 54" src="https://user-images.githubusercontent.com/18017179/51749519-e089be80-20af-11e9-8ca8-6cbd894c837a.png">
