### PR TITLE
Feature/review with ingo

### DIFF
--- a/alv-portal-ui/src/app/widgets/manage-job-ads-widget/job-ad-management-table/job-ad-management-table.component.scss
+++ b/alv-portal-ui/src/app/widgets/manage-job-ads-widget/job-ad-management-table/job-ad-management-table.component.scss
@@ -41,6 +41,7 @@
       border-left: 5px solid $color-primary;
       color: $color-primary;
       cursor: pointer;
+      box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.35);
     }
   }
 

--- a/alv-portal-ui/translations.csv
+++ b/alv-portal-ui/translations.csv
@@ -179,9 +179,9 @@ dashboard,dashboard.job-publication.action,Aktion,Action,Action,Azione
 dashboard,dashboard.job-publication.action.copy,Stellenanzeige duplizieren,Duplicate the job ad,Dupliquer l'annonce,Duplicare l'annuncio
 dashboard,dashboard.job-publication.action.delete,Stellenanzeige abmelden,Cancel job posting,Retirer l'annonce,Cancellare il posto vacante
 dashboard,dashboard.job-publication.action.view,Stellenanzeige sichten,View job ad,Consulter l'annonce,Vedere il posto vacante
-dashboard,dashboard.job-publication.avam,Stellennummer AVAM,Job number AVAM,Numéro de poste PLASTA,N. del posto vacante COLSTA
+dashboard,dashboard.job-publication.avam,Stellennr. AVAM,Job No. AVAM,n° de poste PLASTA,N. del posto vacante COLSTA
 dashboard,dashboard.job-publication.job-name.placeholder,In Stellen suchen,Search jobs,Recherche dans les postes,Ricercare nei posti vacanti
-dashboard,dashboard.job-publication.job-room-id,Stellennummer Job-Room,Job number Job-Room,Numéro de poste Job-Room,N. del posto vacante Job-Room
+dashboard,dashboard.job-publication.job-room-id,Stellennr. Job-Room,Job No. Job-Room,n° de poste Job-Room,N. del posto vacante Job-Room
 dashboard,dashboard.job-publication.job-title,Stellenbezeichnung,Job description,Désignation du poste,Descrizione del posto
 dashboard,dashboard.job-publication.location,Arbeitsort,Place of work,Lieu de travail,Luogo di lavoro
 dashboard,dashboard.job-publication.publication-date,Meldedatum,Registration date,Date de l'annonce,Data dell'annuncio


### PR DESCRIPTION
**1.** Ingo and me tried to fix the problem with long labels in table headings forcing the sort icon to be on the second line (s. screenshot)
<img width="492" alt="screenshot 2019-02-12 at 17 38 40" src="https://user-images.githubusercontent.com/18017179/52651804-24bcf180-2eed-11e9-8cf9-5f4a5a14bc6c.png">

We ended up shorting/abbreviating the labels. We did it only for the word "number" for now. But the "Stellen" part from "Stellenbezeichnung" could - after me - be removed, too. But we were not courageous enough to change texts completely. --> But there is still potential to save some space!!! 
**It's not a CSS issue, it's just really bad texts.**

**2.** Because I was not able to create the same (outer) box-shadow for the job-management-table, I had to create an inner box-shadow. 

<img width="975" alt="screenshot 2019-02-12 at 17 44 30" src="https://user-images.githubusercontent.com/18017179/52652169-e07e2100-2eed-11e9-85f0-d7999c01d9eb.png">
