### PR TITLE
DF 698 max length values for candidate contact form

### DIFF
--- a/alv-portal-ui/src/app/candidate-search/candidate-detail/contact-modal/contact-modal.component.html
+++ b/alv-portal-ui/src/app/candidate-search/candidate-detail/contact-modal/contact-modal.component.html
@@ -6,18 +6,18 @@
            [formGroup]="form">
   <fieldset>
     <alv-input-field label="home.tools.job-publication.contact.salutation"
-                     [maxLength]="TITLE_MAX_LENGTH"
+                     [maxLength]="MAX_LENGTH_150"
                      alvFormControlName="subject">
     </alv-input-field>
     <p>{{ mailBodyPreamble }}</p>
     <alv-input-field label="portal.candidate-detail.anonymous-contact.your-message"
-                     [maxLength]="MESSAGE_MAX_LENGTH"
+                     [maxLength]="MAX_LENGTH_1000"
                      [showCharacterCounter]="true"
                      [multiline]="true"
                      alvFormControlName="personalMessage">
     </alv-input-field>
     <alv-input-field label="candidate-detail.anonymous-contact.company"
-                     [maxLength]="TITLE_MAX_LENGTH"
+                     [maxLength]="MAX_LENGTH_255"
                      alvFormControlName="companyName">
     </alv-input-field>
     <p>{{ 'candidate-detail.anonymous-contact.contact-via.text' | translate }}</p>
@@ -31,6 +31,7 @@
       <alv-input-field label="candidate-detail.anonymous-contact.phone"
                        type="tel"
                        alvFormControlName="phone"
+                       placeholder="home.tools.job-publication.placeholders.phone"
                        *ngIf="form.get('phoneCheckbox').value">
       </alv-input-field>
     </div>
@@ -42,6 +43,7 @@
       </alv-checkbox>
       <alv-input-field label="candidate-detail.anonymous-contact.email"
                        alvFormControlName="email"
+                       placeholder="home.tools.job-publication.placeholders.email"
                        *ngIf="form.get('emailCheckbox').value">
       </alv-input-field>
     </div>
@@ -54,19 +56,23 @@
       <div *ngIf="form.get('postCheckbox').value"
            formGroupName="company">
         <alv-input-field label="candidate-detail.anonymous-contact.company"
+                         [maxLength]="MAX_LENGTH_255"
                          alvFormControlName="companyName">
         </alv-input-field>
         <alv-input-field label="portal.candidate-detail.anonymous-contact.name-lastName"
+                         [maxLength]="MAX_LENGTH_100"
                          alvFormControlName="contactPerson">
         </alv-input-field>
         <div class="form-row">
           <div class="col-md-10">
             <alv-input-field label="candidate-detail.anonymous-contact.street"
+                             [maxLength]="MAX_LENGTH_60"
                              alvFormControlName="companyStreet">
             </alv-input-field>
           </div>
           <div class="col-md-2">
             <alv-input-field label="candidate-detail.anonymous-contact.house"
+                             [maxLength]="MAX_LENGTH_10"
                              alvFormControlName="companyHouseNr">
             </alv-input-field>
           </div>
@@ -74,11 +80,13 @@
         <div class="form-row">
           <div class="col-md-2">
             <alv-input-field label="candidate-detail.anonymous-contact.zip-code"
+                             [maxLength]="MAX_LENGTH_12"
                              alvFormControlName="companyZipCode">
             </alv-input-field>
           </div>
           <div class="col-md-10">
             <alv-input-field label="candidate-detail.anonymous-contact.city"
+                             [maxLength]="MAX_LENGTH_100"
                              alvFormControlName="companyCity">
             </alv-input-field>
           </div>

--- a/alv-portal-ui/src/app/candidate-search/candidate-detail/contact-modal/contact-modal.component.ts
+++ b/alv-portal-ui/src/app/candidate-search/candidate-detail/contact-modal/contact-modal.component.ts
@@ -169,7 +169,7 @@ export class ContactModalComponent extends AbstractSubscriber implements OnInit 
       contactPerson: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_100)]],
       companyName: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_255)]],
       companyStreet: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_60)]],
-      companyHouseNr: [null, [Validators.required, patternInputValidator(HOUSE_NUMBER_REGEX), Validators.maxLength(this.MAX_LENGTH_10)]],
+      companyHouseNr: [null, [patternInputValidator(HOUSE_NUMBER_REGEX), Validators.maxLength(this.MAX_LENGTH_10)]],
       companyZipCode: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_12)]],
       companyCity: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_100)]],
       countryIsoCode: [null, Validators.required]

--- a/alv-portal-ui/src/app/candidate-search/candidate-detail/contact-modal/contact-modal.component.ts
+++ b/alv-portal-ui/src/app/candidate-search/candidate-detail/contact-modal/contact-modal.component.ts
@@ -49,9 +49,13 @@ interface ContactCandidateCompanyFormValues {
 })
 export class ContactModalComponent extends AbstractSubscriber implements OnInit {
 
-  readonly TITLE_MAX_LENGTH = 150;
-
-  readonly MESSAGE_MAX_LENGTH = 1000;
+  readonly MAX_LENGTH_10 = 10;
+  readonly MAX_LENGTH_12 = 12;
+  readonly MAX_LENGTH_60 = 60;
+  readonly MAX_LENGTH_100 = 100;
+  readonly MAX_LENGTH_150 = 150;
+  readonly MAX_LENGTH_255 = 255;
+  readonly MAX_LENGTH_1000 = 1000;
 
   readonly LABEL_VALUES: string[] = [
     'candidate-detail.candidate-anonymous-contact.subject',
@@ -147,9 +151,9 @@ export class ContactModalComponent extends AbstractSubscriber implements OnInit 
 
   private prepareForm(): FormGroup {
     return this.fb.group({
-      subject: [null, Validators.required],
-      personalMessage: [null, Validators.required],
-      companyName: [null, Validators.required],
+      subject: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_150)]],
+      personalMessage: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_1000)]],
+      companyName: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_255)]],
       phoneCheckbox: [true],
       phone: [null],
       emailCheckbox: [true],
@@ -162,12 +166,12 @@ export class ContactModalComponent extends AbstractSubscriber implements OnInit 
 
   private prepareCompanyFormGroup() {
     return this.fb.group({
-      contactPerson: [null, Validators.required],
-      companyName: [null, Validators.required],
-      companyStreet: [null, Validators.required],
-      companyHouseNr: [null, [Validators.required, patternInputValidator(HOUSE_NUMBER_REGEX)]],
-      companyZipCode: [null, Validators.required],
-      companyCity: [null, Validators.required],
+      contactPerson: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_100)]],
+      companyName: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_255)]],
+      companyStreet: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_60)]],
+      companyHouseNr: [null, [Validators.required, patternInputValidator(HOUSE_NUMBER_REGEX), Validators.maxLength(this.MAX_LENGTH_10)]],
+      companyZipCode: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_12)]],
+      companyCity: [null, [Validators.required, Validators.maxLength(this.MAX_LENGTH_100)]],
       countryIsoCode: [null, Validators.required]
     });
   }


### PR DESCRIPTION
https://alv-ch.atlassian.net/wiki/spaces/OS/pages/269877655/UI+Kandidat+kontaktieren
- adding max length values as defined with new changes in specifications : 
title: 150; message: 1000; company: 255; name, last name: each 50, combined 100; street: 60; houseNo: 10; postal code: 12; city: 100
- house number is not mandatory field now
- adding placeholders for phone and email as specified