### PR TITLE
DF 775 logo arbeit.swiss on some browsers too small

### DIFF
--- a/alv-portal-ui/src/app/shared/layout/main-navigation/main-navigation.component.html
+++ b/alv-portal-ui/src/app/shared/layout/main-navigation/main-navigation.component.html
@@ -36,8 +36,9 @@
      [href]="'home.title.portal-url' | translate">
     <img src="assets/img/logo_arbeit_swiss_without_text.svg"
          class="d-inline-block logo-arbeit-swiss"
-         aria-hidden="true">
-    <span class="nav-text"
+         aria-hidden="true"
+         height="22">
+    <span class="nav-text logo-text"
           [innerHTML]="'home.title.cms' | translate"></span>
   </a>
 
@@ -92,8 +93,9 @@
      [href]="'home.title.portal-url' | translate">
     <img src="assets/img/logo_arbeit_swiss_without_text.svg"
          class="d-inline-block logo-arbeit-swiss"
-         aria-hidden="true">
-    <span class="nav-text"
+         aria-hidden="true"
+         height="22">
+    <span class="nav-text logo-text"
           [innerHTML]="'home.title.cms' | translate"></span>
   </a>
   <hr>

--- a/alv-portal-ui/src/app/shared/layout/main-navigation/main-navigation.component.scss
+++ b/alv-portal-ui/src/app/shared/layout/main-navigation/main-navigation.component.scss
@@ -223,7 +223,11 @@
 
 .logo-arbeit-swiss {
   width: 1em;
-  margin: 0 .7rem 0 .4rem;
+  margin-left: 0.3rem;
+}
+
+.logo-text {
+  margin-left: 0.7rem;
 }
 
 .not-hoverable {


### PR DESCRIPTION
the most problematic was IE11 ....
comparison of the menu on Chrome-Firefox-IE11 (expanded and minimized menu)
On Edge is also the same.

![browsers-logo-arbeitswiss](https://user-images.githubusercontent.com/45841069/53807124-104da100-3f4f-11e9-97c6-c986d4ffae10.png)
