### PR TITLE
DF-848 put back weird imports but made them not weird

### DIFF
--- a/alv-portal-ui/src/app/shared/layout/layout.module.ts
+++ b/alv-portal-ui/src/app/shared/layout/layout.module.ts
@@ -10,7 +10,11 @@ import {
   NgbAlertModule,
   NgbCollapseModule,
   NgbDropdown,
+  NgbDropdownAnchor,
+  NgbDropdownItem,
+  NgbDropdownMenu,
   NgbDropdownModule,
+  NgbDropdownToggle,
   NgbModalModule,
   NgbPopoverModule,
   NgbTooltip,
@@ -107,6 +111,7 @@ import { LinkPanelComponent } from './link-panel/link-panel.component';
     ConfirmModalComponent,
     LocalLoginComponent,
     ContactModalComponent
+
   ],
   exports: [
     NavigationContainerComponent,
@@ -121,6 +126,10 @@ import { LinkPanelComponent } from './link-panel/link-panel.component';
     NgbAlert,
     NgbTooltip,
     NgbDropdown,
+    NgbDropdownMenu,
+    NgbDropdownToggle,
+    NgbDropdownAnchor,
+    NgbDropdownItem,
     LanguageSkillsComponent,
     ModalComponent,
     StepIndicatorComponent,


### PR DESCRIPTION
closely related to this: 
https://github.com/alv-ch/alv-portal/pull/391/files

fixes the issue with not working dropdown in job details and candidate details page: 

![image](https://user-images.githubusercontent.com/697308/54834370-4f565300-4cc0-11e9-8338-4f7a4a76f735.png)

----
Now it's good: 
----

![image](https://user-images.githubusercontent.com/697308/54834321-3baaec80-4cc0-11e9-9eb4-e4885840d77d.png)
