### PR TITLE
DF 919 - job date not shown properly in IE

### DIFF
--- a/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
+++ b/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
@@ -8,7 +8,7 @@
       <h3 class="title order-2 order-sm-1 mb-0 w-100"
           [innerHTML]="result.title | safeHtml">
       </h3>
-      <div class="order-1 order-sm-2 d-flex">
+      <div class="order-1 order-sm-2">
         <small class="date"
                [class.has-actions]="result.hasActions">
           {{ result.header | localeAwareDate }}

--- a/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
+++ b/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
@@ -8,8 +8,8 @@
       <h3 class="title order-2 order-sm-1 mb-0 w-100"
           [innerHTML]="result.title | safeHtml">
       </h3>
-      <div class="order-1 order-sm-2">
-        <small class="date text-truncate"
+      <div class="order-1 order-sm-2 d-flex">
+        <small class="date"
                [class.has-actions]="result.hasActions">
           {{ result.header | localeAwareDate }}
         </small>

--- a/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
+++ b/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
@@ -8,7 +8,7 @@
       <h3 class="title order-2 order-sm-1 mb-0 w-100"
           [innerHTML]="result.title | safeHtml">
       </h3>
-      <div class="order-1 order-sm-2 d-flex">
+      <div class="order-1 order-sm-2">
         <small class="date text-truncate"
                [class.has-actions]="result.hasActions">
           {{ result.header | localeAwareDate }}


### PR DESCRIPTION
Tested in Chrome, Firefox, Edge and IE.
PrtScr from IE, with and without favourite icons.
![with-fav](https://user-images.githubusercontent.com/45841069/56267563-75201d80-60ef-11e9-9c3b-f2eaef370d2e.png)
![without-fav](https://user-images.githubusercontent.com/45841069/56267564-75201d80-60ef-11e9-8777-da21a7a602a1.png)
