### PR TITLE
Add title instead of tooltip to favourite and note icons

### DIFF
--- a/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
+++ b/alv-portal-ui/src/app/shared/layout/result-list-item/result-list-item.component.html
@@ -33,6 +33,7 @@
        class="actions-area d-flex">
     <button class="btn btn-toggle-icon mr-1"
             (click)="favouritesClick.emit()"
+            [title]="'portal.job-ad-favourites.tooltip.' + (result.isFavourite ? 'remove-favourite' : 'add-favourite') | translate"
             [attr.aria-label]="'portal.job-ad-favourites.tooltip.' + (result.isFavourite ? 'remove-favourite' : 'add-favourite') | translate">
       <fa-icon *ngIf="result.isFavourite"
                [icon]="['fas', 'star']"></fa-icon>
@@ -41,6 +42,7 @@
     </button>
     <button class="btn btn-toggle-icon"
             (click)="noteClick.emit()"
+            [title]="'portal.job-ad-favourites.tooltip.' + (result.hasNote ? 'edit-note' : 'add-note') | translate"
             [attr.aria-label]="'portal.job-ad-favourites.tooltip.' + (result.hasNote ? 'edit-note' : 'add-note') | translate">
       <fa-icon *ngIf="result.hasNote"
                [icon]="['fas', 'sticky-note']"></fa-icon>


### PR DESCRIPTION
Tested on Windows machine on Chrome, Firefox, Edge and IE.
Title is shown properly on each. Also on different screen resolutions.