### PR TITLE
Fix duplication of job ad: work forms

### DIFF
--- a/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/employment/employment.component.ts
+++ b/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/employment/employment.component.ts
@@ -98,7 +98,7 @@ export class EmploymentComponent extends AbstractSubscriber implements OnInit {
   }
 
   ngOnInit(): void {
-    const { workloadPercentageMin, workloadPercentageMax, duration, immediately, startDate, endDate } = this.employmentFormValue;
+    const { workloadPercentageMin, workloadPercentageMax, duration, immediately, startDate, endDate, workForms } = this.employmentFormValue;
 
     this.employment = this.fb.group({
       workloadPercentageMin: [workloadPercentageMin, [
@@ -119,7 +119,7 @@ export class EmploymentComponent extends AbstractSubscriber implements OnInit {
         disabled: duration !== EmploymentDuration.TEMPORARY
       }, [Validators.required]],
       workForms: this.fb.group(this.workFormOptions.reduce((acc, curr) => {
-        acc[curr.value] = false;
+        acc[curr.value] = workForms[curr.value];
         return acc;
       }, {}))
     });

--- a/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/job-publication-form.mapper.ts
+++ b/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/job-publication-form.mapper.ts
@@ -126,7 +126,7 @@ function mapToEmploymentFormValue(employment: Employment): EmploymentFormValue {
     workloadPercentageMax: parseInt(employment.workloadPercentageMax.toString(), 10),
     duration: mapToDuration(employment),
     workForms: Object.keys(WorkForm).reduce((acc, curr) => {
-      acc[curr] = !!employment.workForms[curr];
+      acc[curr] = employment.workForms.includes(curr);
       return acc;
     }, {})
   };


### PR DESCRIPTION
The work forms have not been properly preset if a job ad was duplicated.