### PR TITLE
Bugfix/df 1448 parent drag drop area

### DIFF
--- a/alv-portal-ui/src/app/app.component.ts
+++ b/alv-portal-ui/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { AuthenticationService } from './core/auth/authentication.service';
 import {
   filter,
@@ -26,6 +26,7 @@ import { GATrackingService } from './shared/tracking/g-a-tracking.service';
 import { ScrollService } from './core/scroll.service';
 import { Observable } from 'rxjs';
 import { ProfileInfoService } from './shared/layout/header/profile-info.service';
+import { DOCUMENT } from '@angular/common';
 
 const FALLBACK_TITLE_KEY = 'global.title';
 
@@ -48,7 +49,8 @@ export class AppComponent implements OnInit {
               private activatedRoute: ActivatedRoute,
               private authenticationService: AuthenticationService,
               private profileInfoService: ProfileInfoService,
-              private scrollService: ScrollService) {
+              private scrollService: ScrollService,
+              @Inject(DOCUMENT) private document: any) {
   }
 
   ngOnInit() {
@@ -71,6 +73,7 @@ export class AppComponent implements OnInit {
 
     this.handleTitle(activatedRoute$);
 
+    this.disableFileDragDropGlobally();
   }
 
   private handleGuardErrors() {
@@ -165,4 +168,20 @@ export class AppComponent implements OnInit {
     });
   }
 
+  private disableFileDragDropGlobally() {
+    const disabledDragDropArea = this.document.body;
+    disabledDragDropArea.addEventListener('dragover', this.preventDefault);
+    disabledDragDropArea.addEventListener('dragleave', this.preventDefault);
+    disabledDragDropArea.addEventListener('drop', this.preventDefault);
+  }
+
+  private preventDefault(event: DragEvent) {
+    for (let i = 0; i < event.dataTransfer.items.length; i++) {
+      if (event.dataTransfer.items[i].kind === 'file') {
+        event.stopPropagation();
+        event.preventDefault();
+        return;
+      }
+    }
+  }
 }

--- a/alv-portal-ui/src/app/app.component.ts
+++ b/alv-portal-ui/src/app/app.component.ts
@@ -27,6 +27,7 @@ import { ScrollService } from './core/scroll.service';
 import { Observable } from 'rxjs';
 import { ProfileInfoService } from './shared/layout/header/profile-info.service';
 import { DOCUMENT } from '@angular/common';
+import { FileDragDropService } from './shared/forms/input/file-input/file-drag-drop.service';
 
 const FALLBACK_TITLE_KEY = 'global.title';
 
@@ -50,6 +51,7 @@ export class AppComponent implements OnInit {
               private authenticationService: AuthenticationService,
               private profileInfoService: ProfileInfoService,
               private scrollService: ScrollService,
+              private fileDragDropService: FileDragDropService,
               @Inject(DOCUMENT) private document: any) {
   }
 
@@ -73,7 +75,7 @@ export class AppComponent implements OnInit {
 
     this.handleTitle(activatedRoute$);
 
-    this.disableFileDragDropGlobally();
+    this.fileDragDropService.disableFileDragDropGlobally();
   }
 
   private handleGuardErrors() {
@@ -166,22 +168,5 @@ export class AppComponent implements OnInit {
       this.titleService.setTitle(title);
       this.trackingService.trackCurrentPage(title);
     });
-  }
-
-  private disableFileDragDropGlobally() {
-    const disabledDragDropArea = this.document.body;
-    disabledDragDropArea.addEventListener('dragover', this.preventDefaultForFiles);
-    disabledDragDropArea.addEventListener('dragleave', this.preventDefaultForFiles);
-    disabledDragDropArea.addEventListener('drop', this.preventDefaultForFiles);
-  }
-
-  private preventDefaultForFiles(event: DragEvent) {
-    for (let i = 0; i < event.dataTransfer.items.length; i++) {
-      if (event.dataTransfer.items[i].kind === 'file') {
-        event.stopPropagation();
-        event.preventDefault();
-        return;
-      }
-    }
   }
 }

--- a/alv-portal-ui/src/app/app.component.ts
+++ b/alv-portal-ui/src/app/app.component.ts
@@ -170,12 +170,12 @@ export class AppComponent implements OnInit {
 
   private disableFileDragDropGlobally() {
     const disabledDragDropArea = this.document.body;
-    disabledDragDropArea.addEventListener('dragover', this.preventDefault);
-    disabledDragDropArea.addEventListener('dragleave', this.preventDefault);
-    disabledDragDropArea.addEventListener('drop', this.preventDefault);
+    disabledDragDropArea.addEventListener('dragover', this.preventDefaultForFiles);
+    disabledDragDropArea.addEventListener('dragleave', this.preventDefaultForFiles);
+    disabledDragDropArea.addEventListener('drop', this.preventDefaultForFiles);
   }
 
-  private preventDefault(event: DragEvent) {
+  private preventDefaultForFiles(event: DragEvent) {
     for (let i = 0; i < event.dataTransfer.items.length; i++) {
       if (event.dataTransfer.items[i].kind === 'file') {
         event.stopPropagation();

--- a/alv-portal-ui/src/app/online-services/application-documents/application-documents-overview/application-document-modal/application-document-modal.component.html
+++ b/alv-portal-ui/src/app/online-services/application-documents/application-documents-overview/application-document-modal/application-document-modal.component.html
@@ -6,6 +6,7 @@
            cancelLabel="portal.application-documents.edit-create-modal.cancel-button.label"
            (cancelAction)="cancel()"
            [formGroup]="form"
+           id="applicationDocumentDragDropArea"
            [loadingSubscription]="uploadProgressSubscription">
   <alv-alert *ngIf="showUploadInstruction"
              (dismiss)="dismissUploadInstruction()"
@@ -40,6 +41,7 @@
                   [accept]="ACCEPTED_FILE_TYPES"
                   [maxFileSize]="MAX_FILE_SIZE"
                   [showRemoveButton]="true"
+                  parentDragDropAreaId="applicationDocumentDragDropArea"
                   [validationMessages]="fileValidationMessages">
   </alv-file-input>
 

--- a/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.directive.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.directive.ts
@@ -28,7 +28,7 @@ export class FileDragDropDirective implements OnInit, OnDestroy {
 
   private onDragLeaveFn = this.onDragLeave.bind(this);
 
-  private onDropFn = this.ondrop.bind(this);
+  private onDropFn = this.onDrop.bind(this);
 
   private dragDropArea: Element;
 
@@ -60,7 +60,7 @@ export class FileDragDropDirective implements OnInit, OnDestroy {
     }
   }
 
-  ondrop(evt) {
+  onDrop(evt) {
     if (!this.dragDropDisabled) {
       evt.preventDefault();
       evt.stopPropagation();

--- a/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.directive.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.directive.ts
@@ -1,26 +1,50 @@
 import {
   Directive,
+  ElementRef,
   EventEmitter,
   HostBinding,
-  HostListener,
+  Inject,
   Input,
+  OnDestroy,
+  OnInit,
   Output
 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 
 @Directive({
   selector: '[alvFileDragDrop]'
 })
-export class FileDragDropDirective {
-
-  constructor() { }
+export class FileDragDropDirective implements OnInit, OnDestroy {
 
   @Output() fileDropped = new EventEmitter<File[]>();
 
   @Input() dragDropDisabled: boolean;
 
+  @Input() parentDragDropAreaId?: string;
+
   @HostBinding('class.alv-dragover') private dragover: boolean;
 
-  @HostListener('dragover', ['$event']) onDragOver(evt) {
+  private onDragOverFn = this.onDragOver.bind(this);
+
+  private onDragLeaveFn = this.onDragLeave.bind(this);
+
+  private onDropFn = this.ondrop.bind(this);
+
+  private dragDropArea: Element;
+
+  constructor(@Inject(DOCUMENT) private document: any,
+              private element: ElementRef) {
+  }
+
+  ngOnInit() {
+    this.setupDragDropArea();
+  }
+
+  ngOnDestroy() {
+    this.teardownDragDropArea();
+  }
+
+  onDragOver(evt) {
     if (!this.dragDropDisabled) {
       evt.preventDefault();
       evt.stopPropagation();
@@ -28,7 +52,7 @@ export class FileDragDropDirective {
     }
   }
 
-  @HostListener('dragleave', ['$event']) onDragLeave(evt) {
+  onDragLeave(evt) {
     if (!this.dragDropDisabled) {
       evt.preventDefault();
       evt.stopPropagation();
@@ -36,7 +60,7 @@ export class FileDragDropDirective {
     }
   }
 
-  @HostListener('drop', ['$event']) ondrop(evt) {
+  ondrop(evt) {
     if (!this.dragDropDisabled) {
       evt.preventDefault();
       evt.stopPropagation();
@@ -47,4 +71,22 @@ export class FileDragDropDirective {
       }
     }
   }
+
+  private setupDragDropArea() {
+    this.dragDropArea = this.document.querySelector('#' + this.parentDragDropAreaId) || this.element.nativeElement;
+    if (this.dragDropArea) {
+      this.dragDropArea.addEventListener('dragover', this.onDragOverFn);
+      this.dragDropArea.addEventListener('dragleave', this.onDragLeaveFn);
+      this.dragDropArea.addEventListener('drop', this.onDropFn);
+    }
+  }
+
+  private teardownDragDropArea() {
+    if (this.dragDropArea) {
+      this.dragDropArea.removeEventListener('dragover', this.onDragOverFn);
+      this.dragDropArea.removeEventListener('dragleave', this.onDragLeaveFn);
+      this.dragDropArea.removeEventListener('drop', this.onDropFn);
+    }
+  }
+
 }

--- a/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.service.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.service.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FileDragDropService {
+
+  constructor(@Inject(DOCUMENT) private document: any) {
+    this.disableFileDragDropGlobally();
+  }
+
+  disableFileDragDropGlobally() {
+    const disabledDragDropArea = this.document.body;
+    disabledDragDropArea.addEventListener('dragover', this.preventDefaultForFiles);
+    disabledDragDropArea.addEventListener('dragleave', this.preventDefaultForFiles);
+    disabledDragDropArea.addEventListener('drop', this.preventDefaultForFiles);
+  }
+
+  private preventDefaultForFiles(event: DragEvent) {
+    for (let i = 0; i < event.dataTransfer.items.length; i++) {
+      if (event.dataTransfer.items[i].kind === 'file') {
+        event.stopPropagation();
+        event.preventDefault();
+        return;
+      }
+    }
+  }
+}

--- a/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.service.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/file-input/file-drag-drop.service.ts
@@ -7,7 +7,6 @@ import { DOCUMENT } from '@angular/common';
 export class FileDragDropService {
 
   constructor(@Inject(DOCUMENT) private document: any) {
-    this.disableFileDragDropGlobally();
   }
 
   disableFileDragDropGlobally() {

--- a/alv-portal-ui/src/app/shared/forms/input/file-input/file-input.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/file-input/file-input.component.html
@@ -11,7 +11,7 @@
          name="files"
          [attr.multiple]="maxFilesCount > 1 ? true : null"
          [accept]="accept"
-         (change)="uploadFile(($event.target || $event.srcElement).files);">
+         (change)="uploadFile(($event.target || $event.srcElement)['files']);">
 </button>
 
 <div [class.disabled]="control.disabled">
@@ -19,6 +19,7 @@
        alvFileDragDrop
        *ngIf="!isUploadLimitReached()"
        [dragDropDisabled]="control.disabled"
+       [parentDragDropAreaId]="parentDragDropAreaId"
        (fileDropped)="uploadFile($event)">
     <fa-icon [icon]="['fas', 'cloud-upload-alt']"
              class="mr-1">

--- a/alv-portal-ui/src/app/shared/forms/input/file-input/file-input.component.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/file-input/file-input.component.ts
@@ -1,4 +1,12 @@
-import { Component, Host, Input, Optional, SkipSelf } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  Host,
+  Inject,
+  Input,
+  Optional,
+  SkipSelf
+} from '@angular/core';
 import { BytesPipe } from '../../../pipes/bytes.pipe';
 import { AbstractInput } from '../abstract-input';
 import { ControlContainer } from '@angular/forms';
@@ -11,7 +19,7 @@ import { Observable, of } from 'rxjs';
   templateUrl: './file-input.component.html',
   styleUrls: ['./file-input.component.scss']
 })
-export class FileInputComponent extends AbstractInput {
+export class FileInputComponent extends AbstractInput implements AfterViewInit {
 
   private readonly ALL_FILE_TYPES = '*/*';
 
@@ -40,6 +48,8 @@ export class FileInputComponent extends AbstractInput {
    * If set to false, the remove button will be hidden and selected files will be overridden
    */
   @Input() showRemoveButton = true;
+
+  @Input() parentDragDropAreaId?: string;
 
   files: File[] = [];
 

--- a/alv-portal-ui/src/app/shared/forms/input/file-input/file-input.component.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/file-input/file-input.component.ts
@@ -19,7 +19,7 @@ import { Observable, of } from 'rxjs';
   templateUrl: './file-input.component.html',
   styleUrls: ['./file-input.component.scss']
 })
-export class FileInputComponent extends AbstractInput implements AfterViewInit {
+export class FileInputComponent extends AbstractInput {
 
   private readonly ALL_FILE_TYPES = '*/*';
 


### PR DESCRIPTION
Comment from René Tobler: 
> Beim Training und beim Testing habe ich festgestellt, dass der User das Dokument effektiv in die Drag & Drop Area ziehen und warten muss, bis sie beim Mouser Over rot wird. ABER…
> Zieht man die Datei nicht genau dorthin, sondern lässt sie irgendwo im Hochladedialog los, öffnet der Browser stattdessen das PDF-File.
> [...]
> Das ist sicher kein Standardverhalten und muss noch korrigiert werden.

What I did:
- Block all default behaviour of the browser regarding opening files on drag'n'drop (`file-drag-drop.service.ts`)
- It's still possible to drag'n'drop e.g. text from a document, only file related drag'n'drop events are prevented.
- Improve the `file-drag-drop.directive.ts`: make it accept an id of a parent element, extending the effective drag'n'drop area (like in JIRA).