### PR TITLE
Bugfix/df 719 typeahead input max length

### DIFF
--- a/alv-portal-ui/src/app/shared/forms/input/typeahead/multi-typeahead/multi-typeahead.component.html
+++ b/alv-portal-ui/src/app/shared/forms/input/typeahead/multi-typeahead/multi-typeahead.component.html
@@ -1,6 +1,6 @@
 <div class="w-100 form-group"
      [container]="tooltipContainer"
-     [ngbTooltip]="tooltip ? (tooltip | translate): false"
+     [ngbTooltip]="tooltip ? (tooltip | translate): ''"
      [placement]="tooltipPlacement"
      tooltipClass="typeahead-tooltip"
      [autoClose]="'outside'"

--- a/alv-portal-ui/src/app/shared/forms/input/typeahead/multi-typeahead/multi-typeahead.component.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/typeahead/multi-typeahead/multi-typeahead.component.ts
@@ -135,6 +135,9 @@ export class MultiTypeaheadComponent extends AbstractInput implements OnInit, Af
 
   getInputWidth(): string {
     const value = this.inputValue || '';
+    if (value.length > 10) {
+      return '100%';
+    }
     if (value.length > 0) {
       return `${value.length}em`;
     }


### PR DESCRIPTION
To understand the bug just input a lot of text into a multi-typeahead. It will grow further and further and finally mess up the layout. I've added a "guard" that sets the width to `100%` for input strings longer than 10. I've tested it on different screen sizes.