### PR TITLE
Bugfix/df 1654 email validation regex

### DIFF
--- a/alv-portal-ui/src/app/admin/api-user-management/api-user-modal/api-user-modal.component.ts
+++ b/alv-portal-ui/src/app/admin/api-user-management/api-user-modal/api-user-modal.component.ts
@@ -6,6 +6,7 @@ import { ApiUserManagementRepository } from '../../../shared/backend-services/ap
 import { patternInputValidator } from '../../../shared/forms/input/input-field/pattern-input.validator';
 import { EMAIL_REGEX } from '../../../shared/forms/regex-patterns';
 import { take } from 'rxjs/operators';
+import { emailInputValidator } from '../../../shared/forms/input/input-field/email-input.validator';
 
 @Component({
   selector: 'alv-api-user-modal',
@@ -33,9 +34,9 @@ export class ApiUserModalComponent implements OnInit {
     this.form = this.fb.group({
       username: [null, Validators.required],
       companyName: [null, Validators.required],
-      companyEmail: [null, [Validators.required, patternInputValidator(EMAIL_REGEX)]],
+      companyEmail: [null, [Validators.required, emailInputValidator()]],
       technicalContactName: [null, Validators.required],
-      technicalContactEmail: [null, [Validators.required, patternInputValidator(EMAIL_REGEX)]]
+      technicalContactEmail: [null, [Validators.required, emailInputValidator()]]
     });
 
     this.patchFormValues();

--- a/alv-portal-ui/src/app/admin/user-info/user-info.component.ts
+++ b/alv-portal-ui/src/app/admin/user-info/user-info.component.ts
@@ -16,6 +16,7 @@ import { Notification, NotificationType } from '../../shared/layout/notification
 import { UserInfoBadge, UserInfoBadgesMapperService } from './user-info-badges-mapper.service';
 import { ModalService } from '../../shared/layout/modal/modal.service';
 import { ConfirmModalConfig } from '../../shared/layout/modal/confirm-modal/confirm-modal-config.model';
+import { emailInputValidator } from '../../shared/forms/input/input-field/email-input.validator';
 
 const ALERTS = {
   userNotFoundByEmail: {
@@ -214,7 +215,7 @@ export class UserInfoComponent extends AbstractSubscriber implements OnInit {
     if (newValue === UserSearchParameterTypes.EMAIL) {
       this.formPlaceholder = 'portal.admin.user-info.use.search.placeholders.email';
       this.formLabel = 'portal.admin.user-info.user-info.email';
-      validator = patternInputValidator(EMAIL_REGEX);
+      validator = emailInputValidator();
     } else {
       this.formPlaceholder = 'portal.admin.user-info.use.search.placeholders.person-nr';
       this.formLabel = 'portal.admin.user-info.stes-info.pn';

--- a/alv-portal-ui/src/app/candidate/candidate-search/candidate-detail/contact-modal/contact-modal.component.ts
+++ b/alv-portal-ui/src/app/candidate/candidate-search/candidate-detail/contact-modal/contact-modal.component.ts
@@ -27,6 +27,7 @@ import { patternInputValidator } from '../../../../shared/forms/input/input-fiel
 import { atLeastOneRequiredValidator } from '../../../../shared/forms/input/validators/at-least-one-required.validator';
 import { SelectableOption } from '../../../../shared/forms/input/selectable-option.model';
 import { IsoCountryService } from '../../../../shared/localities/iso-country.service';
+import { emailInputValidator } from '../../../../shared/forms/input/input-field/email-input.validator';
 
 interface ContactCandidateFormValues {
   subject: string;
@@ -137,7 +138,7 @@ export class ContactModalComponent extends AbstractSubscriber implements OnInit 
       takeUntil(this.ngUnsubscribe))
       .subscribe(([emailCheckBoxEnabled, company]) => {
         if (emailCheckBoxEnabled) {
-          this.form.get('email').setValidators([Validators.required, patternInputValidator(EMAIL_REGEX)]);
+          this.form.get('email').setValidators([Validators.required, emailInputValidator()]);
           this.patchEmailValue(company.email);
         } else {
           this.form.get('email').clearValidators();

--- a/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/application/application.component.ts
+++ b/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/application/application.component.ts
@@ -9,6 +9,7 @@ import { startWith, takeUntil } from 'rxjs/operators';
 import { emptyPostAddressFormValue, PostAddressFormValue } from '../post-address-form/post-address-form-value.types';
 import { JobPublicationFormValueKeys } from '../job-publication-form-value.types';
 import { atLeastOneRequiredValidator } from '../../../../shared/forms/input/validators/at-least-one-required.validator';
+import { emailInputValidator } from '../../../../shared/forms/input/input-field/email-input.validator';
 
 
 interface SelectedApplicationTypes {
@@ -68,7 +69,7 @@ export class ApplicationComponent extends AbstractSubscriber implements OnInit {
       ]],
       emailAddress: [emailAddress, [
         Validators.required,
-        patternInputValidator(EMAIL_REGEX),
+        emailInputValidator(),
         Validators.maxLength(this.EMAIL_MAX_LENGTH)
       ]],
       phoneNumber: [phoneNumber, [

--- a/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/contact/contact.component.ts
+++ b/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/contact/contact.component.ts
@@ -7,6 +7,7 @@ import { EMAIL_REGEX } from '../../../../shared/forms/regex-patterns';
 import { ContactFormValue } from './contact-form-value.types';
 import { patternInputValidator } from '../../../../shared/forms/input/input-field/pattern-input.validator';
 import { JobPublicationFormValueKeys } from '../job-publication-form-value.types';
+import { emailInputValidator } from '../../../../shared/forms/input/input-field/email-input.validator';
 
 @Component({
   selector: 'alv-contact',
@@ -80,7 +81,7 @@ export class ContactComponent implements OnInit {
         phoneInputValidator()
       ]],
       email: [email, [
-        Validators.required, patternInputValidator(EMAIL_REGEX),
+        Validators.required, emailInputValidator(),
         Validators.maxLength(this.EMAIL_MAX_LENGTH)
       ]]
     });

--- a/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/public-contact/public-contact.component.ts
+++ b/alv-portal-ui/src/app/job-advertisement/job-publication/job-publication-form/public-contact/public-contact.component.ts
@@ -8,6 +8,7 @@ import { PublicContactFormValue } from './public-contact-form-value.types';
 import { patternInputValidator } from '../../../../shared/forms/input/input-field/pattern-input.validator';
 import { JobPublicationFormValueKeys } from '../job-publication-form-value.types';
 import { atLeastOneRequiredValidator } from '../../../../shared/forms/input/validators/at-least-one-required.validator';
+import { emailInputValidator } from '../../../../shared/forms/input/input-field/email-input.validator';
 
 @Component({
   selector: 'alv-public-contact',
@@ -68,7 +69,7 @@ export class PublicContactComponent implements OnInit {
         phoneInputValidator()
       ]],
       email: [email, [
-        patternInputValidator(EMAIL_REGEX),
+        emailInputValidator(),
         Validators.maxLength(this.EMAIL_MAX_LENGTH)
       ]]
     }, {

--- a/alv-portal-ui/src/app/job-advertisement/shared/complaint-modal/complaint-modal.component.ts
+++ b/alv-portal-ui/src/app/job-advertisement/shared/complaint-modal/complaint-modal.component.ts
@@ -17,6 +17,7 @@ import { mapFormToDto } from './complaint-request-mapper';
 import { CompanyContactTemplateModel } from '../../../core/auth/company-contact-template-model';
 import { NotificationType } from '../../../shared/layout/notifications/notification.model';
 import { ComplaintType } from '../../../shared/backend-services/complaint/complaint.types';
+import { emailInputValidator } from '../../../shared/forms/input/input-field/email-input.validator';
 
 
 export interface ComplaintFormValue {
@@ -97,7 +98,7 @@ export class ComplaintModalComponent extends AbstractSubscriber implements OnIni
       salutation: [null, Validators.required],
       name: ['', [Validators.required, Validators.maxLength(this.MAX_LENGTH_255)]],
       phone: ['', [Validators.required, phoneInputValidator()]],
-      email: ['', [Validators.required, Validators.maxLength(this.MAX_LENGTH_255), patternInputValidator(EMAIL_REGEX)]],
+      email: ['', [Validators.required, Validators.maxLength(this.MAX_LENGTH_255), emailInputValidator()]],
       complaintMessage: ['', [Validators.required, Validators.maxLength(this.MAX_LENGTH_1000)]]
     });
 

--- a/alv-portal-ui/src/app/online-services/work-efforts/work-effort-form/work-effort-form.component.ts
+++ b/alv-portal-ui/src/app/online-services/work-efforts/work-effort-form/work-effort-form.component.ts
@@ -62,6 +62,7 @@ import {
 import { ScrollService } from '../../../core/scroll.service';
 import { NotificationsService } from '../../../core/notifications.service';
 import { ValidationMessage } from '../../../shared/forms/input/validation-messages/validation-message.model';
+import { emailInputValidator } from '../../../shared/forms/input/input-field/email-input.validator';
 
 const workLoadPrefix = 'portal.work-efforts.edit-form.work-loads';
 const appliedThroughRavPrefix = 'portal.global';
@@ -190,7 +191,7 @@ export class WorkEffortFormComponent extends AbstractSubscriber implements OnIni
       companyEmailAndUrl: this.fb.group(
         {
           email: ['', [
-            patternInputValidator(EMAIL_REGEX),
+            emailInputValidator(),
             Validators.maxLength(this.EMAIL_MAX_LENGTH)
           ]],
           url: ['', [

--- a/alv-portal-ui/src/app/shared/forms/input/input-field/email-input.validator.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/input-field/email-input.validator.ts
@@ -1,0 +1,21 @@
+import { AbstractControl, ValidatorFn } from '@angular/forms';
+import { isValidNumber } from 'libphonenumber-js';
+import { IsoCountryService } from '../../../localities/iso-country.service';
+import { EMAIL_REGEX } from '../../regex-patterns';
+
+export function emailInputValidator(): ValidatorFn {
+
+  return (control: AbstractControl) => {
+    if (control.value) {
+      const emailParts = control.value.split('@');
+      if (emailParts[0].length > 64 || !EMAIL_REGEX.test(control.value)) {
+        return {
+          'emailValidator': {
+            value: control.value
+          }
+        };
+      }
+    }
+    return null;
+  };
+}

--- a/alv-portal-ui/src/app/shared/forms/input/input-field/email-input.validator.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/input-field/email-input.validator.ts
@@ -1,14 +1,28 @@
 import { AbstractControl, ValidatorFn } from '@angular/forms';
-import { isValidNumber } from 'libphonenumber-js';
-import { IsoCountryService } from '../../../localities/iso-country.service';
 import { EMAIL_REGEX } from '../../regex-patterns';
+
+/*
+   In addition to restrictions on syntax, there is a length limit on
+   email addresses.  That limit is a maximum of 64 characters (octets)
+   in the "local part" (before the "@") and a maximum of 255 characters
+   (octets) in the domain part (after the "@") for a total length of 320
+   characters. However, there is a restriction in RFC 2821 on the length of an
+   address in MAIL and RCPT commands of 256 characters.  Since addresses
+   that do not fit in those fields are not normally useful, the upper
+   limit on address lengths should normally be considered to be 256.
+   @link https://www.rfc-editor.org/errata_search.php?eid=1003
+ */
+const EMAIL_LOCAL_MAX_LENGTH = 64;
+const EMAIL_TOTAL_MAX_LENGTH = 256;
 
 export function emailInputValidator(): ValidatorFn {
 
   return (control: AbstractControl) => {
     if (control.value) {
       const emailParts = control.value.split('@');
-      if (emailParts[0].length > 64 || !EMAIL_REGEX.test(control.value)) {
+      if (emailParts[0].length > EMAIL_LOCAL_MAX_LENGTH ||
+          control.value.length > EMAIL_TOTAL_MAX_LENGTH ||
+          !EMAIL_REGEX.test(control.value)) {
         return {
           'emailValidator': {
             value: control.value

--- a/alv-portal-ui/src/app/shared/forms/input/input-field/pattern-input.validator.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/input-field/pattern-input.validator.ts
@@ -13,12 +13,6 @@ export function patternInputValidator(regex: RegExp): ValidatorFn {
     if (control.value && regex) {
       if (!regex.test(control.value)) {
         switch (String(regex)) {
-          case String(EMAIL_REGEX):
-            return {
-              'emailValidator': {
-                value: control.value
-              }
-            };
           case String(HOUSE_NUMBER_REGEX):
             return {
               'houseNumValidator': {

--- a/alv-portal-ui/src/app/shared/user-settings/company-contact-management/company-contact-management.component.ts
+++ b/alv-portal-ui/src/app/shared/user-settings/company-contact-management/company-contact-management.component.ts
@@ -14,6 +14,7 @@ import { AuthenticationService } from '../../../core/auth/authentication.service
 import { AbstractSubscriber } from '../../../core/abstract-subscriber';
 import { CompanyContactTemplateModel } from '../../../core/auth/company-contact-template-model';
 import { CompanyContactTemplate } from '../../backend-services/user-info/user-info.types';
+import { emailInputValidator } from '../../forms/input/input-field/email-input.validator';
 
 interface CompanyContactFormValue {
   salutation: Salutation;
@@ -96,7 +97,7 @@ export class CompanyContactManagementComponent extends AbstractSubscriber implem
       firstName: [{value: null, disabled: true}, [Validators.required]],
       lastName: [{value: null, disabled: true}, [Validators.required]],
       phone: [null, [Validators.required, phoneInputValidator()]],
-      email: [null, [Validators.required, patternInputValidator(EMAIL_REGEX)]],
+      email: [null, [Validators.required, emailInputValidator()]],
       companyName: [null, [Validators.required]],
       companyStreet: [null, [Validators.required]],
       companyHouseNr: [null, [Validators.required, patternInputValidator(HOUSE_NUMBER_REGEX)]],


### PR DESCRIPTION
I've created a dedicated validator for email conforming with RFC 3696:

> In addition to restrictions on syntax, there is a length limit on
   email addresses.  That limit is a maximum of 64 characters (octets)
   in the "local part" (before the "@") and a maximum of 255 characters
   (octets) in the domain part (after the "@") for a total length of 320
   characters. However, there is a restriction in RFC 2821 on the length of an
   address in MAIL and RCPT commands of 256 characters.  Since addresses
   that do not fit in those fields are not normally useful, the upper
   limit on address lengths should normally be considered to be 256.