### PR TITLE
Fix the URLs for findById and update competence-element

### DIFF
--- a/alv-portal-ui/src/app/shared/backend-services/competence-element/competence-element.repository.ts
+++ b/alv-portal-ui/src/app/shared/backend-services/competence-element/competence-element.repository.ts
@@ -22,7 +22,7 @@ export class CompetenceElementRepository {
   }
 
   findById(id: string): Observable<CompetenceElement> {
-    return this.http.get<CompetenceElement>(`${this.resourceUrl}/${id}`);
+    return this.http.get<CompetenceElement>(this.resourceUrl + id);
   }
 
   findByIds(ids: string[]): Observable<CompetenceElement[]> {
@@ -41,7 +41,7 @@ export class CompetenceElementRepository {
   }
 
   update(id, competenceElement: UpdateCompetenceElement): Observable<CompetenceElement> {
-    return this.http.put<CompetenceElement>(`${this.resourceUrl}/${id}`, competenceElement);
+    return this.http.put<CompetenceElement>(this.resourceUrl + id, competenceElement);
   }
 
 }


### PR DESCRIPTION
There was a double slash ("//") in the URL 