### PR TITLE
bugfix: missing parameters in the query

### DIFF
--- a/alv-portal-ui/src/app/competence-catalog/ch-fiches/competence-set-search-modal/competence-set-search-modal.component.ts
+++ b/alv-portal-ui/src/app/competence-catalog/ch-fiches/competence-set-search-modal/competence-set-search-modal.component.ts
@@ -10,6 +10,7 @@ import { CompetenceSetRepository } from '../../../shared/backend-services/compet
 import { CompetenceSetSearchResult } from '../../../shared/backend-services/competence-catalog/competence-set/competence-set.types';
 import { DEFAULT_PAGE_SIZE } from 'src/app/shared/backend-services/request-util';
 import { getTranslatedString } from '../../shared/shared-competence-catalog.types';
+import { DEFAULT_SORT } from '../../shared/constants';
 
 @Component({
   selector: 'alv-competence-set-search-modal',
@@ -29,7 +30,8 @@ export class CompetenceSetSearchModalComponent implements OnInit {
   constructor(private modal: NgbActiveModal,
               private fb: FormBuilder,
               private i18nService: I18nService,
-              private competenceSetRepository: CompetenceSetRepository) { }
+              private competenceSetRepository: CompetenceSetRepository) {
+  }
 
   ngOnInit() {
     this.form = this.fb.group({
@@ -52,7 +54,14 @@ export class CompetenceSetSearchModalComponent implements OnInit {
   }
 
   private searchCompetenceSets(term: string): Observable<TypeaheadItem<CompetenceSetSearchResult>[]> {
-    return this.competenceSetRepository.search({page: 0, size: DEFAULT_PAGE_SIZE, body: {query: term}}).pipe(
+    return this.competenceSetRepository.search({
+      page: 0,
+      size: DEFAULT_PAGE_SIZE,
+      sort: DEFAULT_SORT.asc,
+      body: {
+        query: term
+      }
+    }).pipe(
       map(competenceSetPage => competenceSetPage
         .content
         .filter(item => this.existingSetIds ? !this.existingSetIds.includes(item.id) : true)

--- a/alv-portal-ui/src/app/competence-catalog/competence-sets/competence-element-search-modal/competence-element-search-modal.component.ts
+++ b/alv-portal-ui/src/app/competence-catalog/competence-sets/competence-element-search-modal/competence-element-search-modal.component.ts
@@ -12,6 +12,7 @@ import { CompetenceElementRepository } from '../../../shared/backend-services/co
 import { I18nService } from '../../../core/i18n.service';
 import { DEFAULT_PAGE_SIZE } from '../../../shared/backend-services/request-util';
 import { getTranslatedString } from '../../shared/shared-competence-catalog.types';
+import { DEFAULT_SORT } from '../../shared/constants';
 
 @Component({
   selector: 'alv-competence-element-search-modal',
@@ -67,7 +68,11 @@ export class CompetenceElementSearchModalComponent implements OnInit {
     return this.competenceElementRepository.search({
       page: 0,
       size: DEFAULT_PAGE_SIZE,
-      body: { query: term, types: [this.elementType] }
+      sort: DEFAULT_SORT.asc,
+      body: {
+        query: term,
+        types: [this.elementType]
+      }
     }).pipe(
       map(competenceElementPage => competenceElementPage
         .content


### PR DESCRIPTION
there was a problem with querying the lists of sets in ch fiches and the list of elems in set. Reason: undefined in sort parameter