### PR TITLE
bugfix for the missing sort in the candidate search

### DIFF
--- a/alv-portal-ui/src/app/shared/backend-services/request-util.ts
+++ b/alv-portal-ui/src/app/shared/backend-services/request-util.ts
@@ -1,5 +1,4 @@
 import { HttpParams } from '@angular/common/http';
-import { noop } from 'rxjs';
 
 export function createRequestOption(req?: any): HttpParams {
   let options: HttpParams = new HttpParams();
@@ -23,10 +22,15 @@ export function createRequestOption(req?: any): HttpParams {
 }
 
 export function createPageableURLSearchParams(req?: PagedSearchRequest): HttpParams {
-  const params = new HttpParams();
-  req.page ? params.set('page', '' + req.page) : noop();
-  req.sort ? params.set('sort', '' + req.sort) : noop();
-  req.size ? params.set('sort', '' + req.size) : noop();
+  let params = new HttpParams()
+    .set('page', '' + req.page)
+    .set('size', '' + req.size);
+  if (req.sort) {
+    if (req.sort instanceof Array) {req.sort.forEach((sort) => params = params.append('sort', sort));
+    } else {
+      params = params.set('sort', req.sort);
+    }
+  }
   return params;
 }
 

--- a/alv-portal-ui/src/app/shared/backend-services/request-util.ts
+++ b/alv-portal-ui/src/app/shared/backend-services/request-util.ts
@@ -1,4 +1,5 @@
 import { HttpParams } from '@angular/common/http';
+import { noop } from 'rxjs';
 
 export function createRequestOption(req?: any): HttpParams {
   let options: HttpParams = new HttpParams();
@@ -22,10 +23,11 @@ export function createRequestOption(req?: any): HttpParams {
 }
 
 export function createPageableURLSearchParams(req?: PagedSearchRequest): HttpParams {
-  return new HttpParams()
-    .set('page', '' + req.page)
-    .set('sort', '' + req.sort)
-    .set('size', '' + req.size);
+  const params = new HttpParams();
+  req.page ? params.set('page', '' + req.page) : noop();
+  req.sort ? params.set('sort', '' + req.sort) : noop();
+  req.size ? params.set('sort', '' + req.size) : noop();
+  return params;
 }
 
 export const DEFAULT_PAGE_SIZE = 20;


### PR DESCRIPTION
previous bugfix related to sort caused another bug, the candidate search stopped working. This fixes both issues. We need to make sure to plan the e2e-test coverage for this case, as it's a very serious use case.