### PR TITLE
DF 1840 search and add icon on the CompetenceSets

### DIFF
--- a/alv-portal-ui/src/app/competence-catalog/shared/competence-set/competence-set.component.ts
+++ b/alv-portal-ui/src/app/competence-catalog/shared/competence-set/competence-set.component.ts
@@ -92,7 +92,7 @@ export class CompetenceSetComponent extends CompetenceCatalogEditorAwareComponen
     this.competenceElementsActions$ = this.isCompetenceCatalogEditor$.pipe(
       map(isEditor => {
         if (isEditor && !this.isInnerElementsReadonly) {
-          return [this.linkElementAction, this.unlinkElementAction, this.backlinkCompetenceSetAction];
+          return [this.unlinkElementAction, this.backlinkCompetenceSetAction];
         } else {
           return [this.backlinkCompetenceSetAction];
         }


### PR DESCRIPTION
- removed SearchAndAdd icon from HandlungswissenIndicator and Wissen
- removed conditionally (when no Handlungswissen present)

When all CompetenceElements are present:
![image](https://user-images.githubusercontent.com/45841069/69542566-fd22ab80-0f8b-11ea-884d-e80c447d4d25.png)

When Handlungswissen is missing:
![image](https://user-images.githubusercontent.com/45841069/69542599-10ce1200-0f8c-11ea-9d27-8d7f2989af0d.png)
