### PR TITLE
DF 1872 fix protractor test

### DIFF
--- a/alv-portal-ui/e2e/src/job-advertisement/job-publication/job-publication.e2e-spec.ts
+++ b/alv-portal-ui/e2e/src/job-advertisement/job-publication/job-publication.e2e-spec.ts
@@ -23,6 +23,8 @@ describe('Job publication page', () => {
     const testTextPrefix = `protractor_${Math.random().toString(36).substr(2, 5)}`;
 
     it('should submit a valid job publication form', () => {
+      page.selectDeLanguage.click();
+
       page.jobDescriptionSection.numberOfJobs.sendKeys('3');
       page.jobDescriptionSection.jobDescription.sendKeys(testTextPrefix + ' description');
 

--- a/alv-portal-ui/e2e/src/job-advertisement/job-publication/job-publication.po.ts
+++ b/alv-portal-ui/e2e/src/job-advertisement/job-publication/job-publication.po.ts
@@ -8,7 +8,7 @@ import { CompanyPo } from './sections/company.po';
 import { ContactPo } from './sections/contact.po';
 import { PublicContactPo } from './sections/public-contact.po';
 import { ApplicationPo } from './sections/application.po';
-import { alvFormControlName } from './selector-utils';
+import { alvFormControlName, getByTest } from './selector-utils';
 
 export class JobPublicationPo {
   private jobPublicationComponentElementFinder = $('alv-job-publication');
@@ -29,6 +29,10 @@ export class JobPublicationPo {
 
   get browserTitle() {
     return browser.getTitle();
+  }
+
+  get selectDeLanguage() {
+    return $(getByTest('language-switcher-de'));
   }
 
   get jobPublicationForm() {


### PR DESCRIPTION
Failing travis build:
https://travis-ci.org/alv-ch/alv-portal/builds/624262248#L10169

- as we are missing occupations for english language, the occupation typeahead was empty, and then the job couldn't be posted
- added selection of DE language at the beginning of the failing test

![image](https://user-images.githubusercontent.com/45841069/70804390-a6540900-1db6-11ea-87b7-f398d472e5a9.png)
