### PR TITLE
remove truncating class in button, as PO wishes

### DIFF
--- a/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.component.html
+++ b/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.component.html
@@ -38,7 +38,7 @@
         <button (click)="manualSubmitProofOfWorkEfforts();$event.stopPropagation()"
                 [disabled]="proofOfWorkEffortsModel.workEfforts.length === 0"
                 type="button"
-                class="btn btn-primary btn-block btn-truncate">
+                class="btn btn-primary btn-block">
           {{ 'portal.work-efforts.proof-of-work-efforts.submit-button.title' | translate }}
         </button>
       </ng-container>


### PR DESCRIPTION
PO didn't like that the button text (which is long) is truncated and only three dots are shown ..
The wish from UI and PO were to keep the full name, no matter of length, and resize the button.
![1](https://user-images.githubusercontent.com/45841069/73552726-0d05b280-4449-11ea-960b-d963963d85ba.png)
![2](https://user-images.githubusercontent.com/45841069/73552727-0d9e4900-4449-11ea-9189-9a325aa69fad.png)
