### PR TITLE
DF-2036 manual submitting

### DIFF
--- a/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.component.html
+++ b/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.component.html
@@ -38,7 +38,7 @@
         <button (click)="manualSubmitProofOfWorkEfforts();$event.stopPropagation()"
                 [disabled]="proofOfWorkEffortsModel.workEfforts.length === 0"
                 type="button"
-                class="btn btn-primary btn-block">
+                class="btn btn-primary btn-block btn-truncate">
           {{ 'portal.work-efforts.proof-of-work-efforts.submit-button.title' | translate }}
         </button>
       </ng-container>

--- a/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.component.ts
+++ b/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.component.ts
@@ -9,7 +9,16 @@ import { FileSaverService } from '../../../../shared/file-saver/file-saver.servi
 import { Observable } from 'rxjs';
 import { ProofOfWorkEffortsSubmitModalComponent } from './proof-of-work-efforts-submit-modal/proof-of-work-efforts-submit-modal.component';
 import { ModalService } from '../../../../shared/layout/modal/modal.service';
-import { addDays, isWithinRange, startOfMonth, startOfToday } from 'date-fns';
+import {
+  addDays,
+  endOfToday,
+  isEqual,
+  isSameDay,
+  isWithinRange,
+  startOfDay,
+  startOfMonth,
+  startOfToday
+} from 'date-fns';
 import {
   daysDifference
 } from '../work-efforts-overview-filter.types';
@@ -81,7 +90,9 @@ export class ProofOfWorkEffortsComponent implements OnInit {
    * f.e. in January, previous ControlPeriod '2019-12' is valid for manual submitting from 01.01. - 05.01 (inclusive)
    */
   private isPreviousPeriodValidForSubmitting(): boolean {
-    return !this.isCurrentPeriod && isWithinRange(addDays(this.proofOfWorkEffortsModel.endDate, 1), startOfMonth(startOfToday()), daysAfterStartOfMonth(5));
+    const endDate = this.proofOfWorkEffortsModel.endDate;
+    const firstOfMonth = startOfMonth(startOfToday());
+    return !this.isCurrentPeriod && isEqual(startOfDay(addDays(endDate, 1)), firstOfMonth) && isWithinRange(startOfToday(), firstOfMonth, daysAfterStartOfMonth(5));
   }
 
 }

--- a/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.model.ts
+++ b/alv-portal-ui/src/app/online-services/work-efforts/work-efforts-overview/proof-of-work-efforts/proof-of-work-efforts.model.ts
@@ -30,6 +30,10 @@ export class ProofOfWorkEffortsModel {
 
   submissionDate: Date;
 
+  startDate: Date;
+
+  endDate: Date;
+
   submissionDateFormat: string;
 
   hasPdfDocument: boolean;
@@ -44,23 +48,27 @@ export class ProofOfWorkEffortsModel {
 
     this.id = this.proofOfWorkEfforts.id;
 
+    this.startDate = new Date(this.proofOfWorkEfforts.startDate + 'T00:00:00');
+
+    this.endDate = new Date(this.proofOfWorkEfforts.endDate + 'T23:59:59');
+
     this.isSentSuccessfully = this.proofOfWorkEfforts.status === ProofOfWorkEffortsStatus.SUBMITTED
       || this.proofOfWorkEfforts.status === ProofOfWorkEffortsStatus.CLOSED;
-
-    this.isCurrentPeriod = this.checkIsCurrentPeriod();
 
     this.isClosed = this.proofOfWorkEfforts.status === ProofOfWorkEffortsStatus.CLOSED;
 
     this.isBeforeEmployment = this.proofOfWorkEfforts.controlPeriod.type === ControlPeriodType.BEFORE_UNEMPLOYMENT;
+
+    this.hasPdfDocument = !!this.proofOfWorkEfforts.documentId;
 
     this.controlPeriodDateString = this.proofOfWorkEfforts.controlPeriod.value;
 
     this.monthValue = this.proofOfWorkEfforts.controlPeriod.value ?
       parseInt(this.proofOfWorkEfforts.controlPeriod.value.split('-')[1], 10) : null;
 
-    this.submissionDate = this.buildSubmissionDateAndFormat();
+    this.isCurrentPeriod = this.checkIsCurrentPeriod();
 
-    this.hasPdfDocument = !!this.proofOfWorkEfforts.documentId;
+    this.submissionDate = this.buildSubmissionDateAndFormat();
 
     this.statusLabel = this.getStatusLabel();
 
@@ -85,9 +93,7 @@ export class ProofOfWorkEffortsModel {
 
   private checkIsCurrentPeriod(): boolean {
     const today = new Date();
-    const startDate = new Date(this.proofOfWorkEfforts.startDate + 'T00:00:00');
-    const endDate = new Date(this.proofOfWorkEfforts.endDate + 'T23:59:59');
-    return today >= startDate && today <= endDate;
+    return today >= this.startDate && today <= this.endDate;
   }
 
   private getStatusLabel(): string {
@@ -109,4 +115,3 @@ export class ProofOfWorkEffortsModel {
   }
 
 }
-

--- a/alv-portal-ui/src/app/shared/forms/input/ngb-date-utils.spec.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/ngb-date-utils.spec.ts
@@ -1,4 +1,11 @@
-import { daysAfterEndOfMonth, fromDate, fromISODate, toISOLocalDate, toISOLocalDateTime } from './ngb-date-utils';
+import {
+  daysAfterEndOfMonth,
+  daysAfterStartOfMonth,
+  fromDate,
+  fromISODate,
+  toISOLocalDate,
+  toISOLocalDateTime
+} from './ngb-date-utils';
 
 describe('NgbDateUtils tests', () => {
 
@@ -166,6 +173,14 @@ describe('NgbDateUtils tests', () => {
     const date = daysAfterEndOfMonth(expectedDay);
     expect(date.getFullYear()).toBe(new Date().getFullYear());
     expect(date.getMonth()).toBe(new Date().getMonth() + 1);
+    expect(date.getDate()).toBe(expectedDay);
+  });
+
+  it('should calculate daysAfterStartOfMonth for currentMonth and specified noOfMonth = 4', () => {
+    const expectedDay = 4;
+    const date = daysAfterStartOfMonth(expectedDay);
+    expect(date.getFullYear()).toBe(new Date().getFullYear());
+    expect(date.getMonth()).toBe(new Date().getMonth());
     expect(date.getDate()).toBe(expectedDay);
   });
 

--- a/alv-portal-ui/src/app/shared/forms/input/ngb-date-utils.ts
+++ b/alv-portal-ui/src/app/shared/forms/input/ngb-date-utils.ts
@@ -1,5 +1,5 @@
 import { NgbDate, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
-import { addDays, endOfMonth, format, startOfToday, subDays } from 'date-fns';
+import { addDays, endOfMonth, format, startOfMonth, startOfToday, subDays } from 'date-fns';
 
 /**
  * Converts a NgbDateStruct with hours and minutes parameters to an (8601) ISOLocalDatetime string representation without timezone information
@@ -116,4 +116,15 @@ export function daysBeforeEndOfMonth(noOfDays: number): Date {
  */
 export function daysAfterEndOfMonth(noOfDays: number): Date {
   return addDays(endOfMonth(startOfToday()), noOfDays);
+}
+
+/**
+ * adding noOfDays from the start of the current month
+ * f.e. for December and noOfDays = 5, it would return 05.12.yyyy
+ * f.e. for April and noOfDays = 5, it would return 05.04.yyyy
+ *
+ * @param noOfDays
+ */
+export function daysAfterStartOfMonth(noOfDays: number): Date {
+  return addDays(startOfMonth(startOfToday()), (noOfDays - 1));
 }


### PR DESCRIPTION
- revert removing truncating class from submit button
- fix order in POWE model (first define fields, then calculate and define methods)
- fix bug : from 1st until 5th of the current month, the button for manual submitting should be visible for the last PREVIOUS CONTROL PERIOD ! (for the CURRENT CONTROL PERIOD button is visible only from the 5 days before end of month)

f.e.
in **January**, 
1) the CURRENT CP is 2020-01 (the button should be visible from 27.01. until 05.02) ; 
2) the PREVIOUS CP is 2019-12 (the button should be visible from 01.01. until 05.01).